### PR TITLE
Add option to ignore articles when sorting

### DIFF
--- a/app/src/main/java/com/mardous/booming/fragments/albums/AlbumListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/albums/AlbumListFragment.kt
@@ -149,7 +149,8 @@ class AlbumListFragment : AbsRecyclerViewCustomGridSizeFragment<AlbumAdapter, Gr
             sortOrderSubmenu.add(0, R.id.action_sort_order_artist, 1, R.string.sort_order_artist)
             sortOrderSubmenu.add(0, R.id.action_sort_order_year, 2, R.string.sort_order_year)
             sortOrderSubmenu.add(0, R.id.action_sort_order_number_of_songs, 3, R.string.sort_order_number_of_songs)
-            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 5, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 4, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_ignore_articles, 5, R.string.sort_order_ignore_articles)
             sortOrderSubmenu.setGroupCheckable(0, true, true)
             sortOrderSubmenu.prepareSortOrder(SortOrder.albumSortOrder)
         }

--- a/app/src/main/java/com/mardous/booming/fragments/artists/ArtistListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/artists/ArtistListFragment.kt
@@ -114,7 +114,8 @@ class ArtistListFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, 
             sortOrderSubmenu.add(0, R.id.action_sort_order_az, 0, R.string.sort_order_az)
             sortOrderSubmenu.add(0, R.id.action_sort_order_number_of_songs, 1, R.string.sort_order_number_of_songs)
             sortOrderSubmenu.add(0, R.id.action_sort_order_number_of_albums, 2, R.string.sort_order_number_of_albums)
-            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 4, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 3, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_ignore_articles, 4, R.string.sort_order_ignore_articles)
             sortOrderSubmenu.setGroupCheckable(0, true, true)
             sortOrderSubmenu.prepareSortOrder(SortOrder.artistSortOrder)
         }

--- a/app/src/main/java/com/mardous/booming/fragments/genres/GenresListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/genres/GenresListFragment.kt
@@ -88,7 +88,8 @@ class GenresListFragment : AbsRecyclerViewCustomGridSizeFragment<GenreAdapter, G
             sortOrderSubmenu.clear()
             sortOrderSubmenu.add(0, R.id.action_sort_order_az, 0, R.string.sort_order_az)
             sortOrderSubmenu.add(0, R.id.action_sort_order_number_of_songs, 1, R.string.sort_order_number_of_songs)
-            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 3, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 2, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_ignore_articles, 3, R.string.sort_order_ignore_articles)
             sortOrderSubmenu.setGroupCheckable(0, true, true)
             sortOrderSubmenu.prepareSortOrder(SortOrder.genreSortOrder)
         }

--- a/app/src/main/java/com/mardous/booming/fragments/songs/SongListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/songs/SongListFragment.kt
@@ -134,7 +134,8 @@ class SongListFragment : AbsRecyclerViewCustomGridSizeFragment<SongAdapter, Grid
             sortOrderSubmenu.add(0, R.id.action_sort_order_duration, 3, R.string.sort_order_duration)
             sortOrderSubmenu.add(0, R.id.action_sort_order_year, 4, R.string.sort_order_year)
             sortOrderSubmenu.add(0, R.id.action_sort_order_date_added, 5, R.string.sort_order_date_added)
-            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 7, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 6, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_ignore_articles, 7, R.string.sort_order_ignore_articles)
             sortOrderSubmenu.setGroupCheckable(0, true, true)
             sortOrderSubmenu.prepareSortOrder(SortOrder.songSortOrder)
         }

--- a/app/src/main/java/com/mardous/booming/fragments/years/YearsListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/years/YearsListFragment.kt
@@ -109,7 +109,8 @@ class YearsListFragment : AbsRecyclerViewCustomGridSizeFragment<YearAdapter, Gri
             sortOrderSubmenu.clear()
             sortOrderSubmenu.add(0, R.id.action_sort_order_year, 0, R.string.sort_order_year)
             sortOrderSubmenu.add(0, R.id.action_sort_order_number_of_songs, 1, R.string.sort_order_number_of_songs)
-            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 3, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_descending, 2, R.string.sort_order_descending)
+            sortOrderSubmenu.add(1, R.id.action_sort_order_ignore_articles, 3, R.string.sort_order_ignore_articles)
             sortOrderSubmenu.setGroupCheckable(0, true, true)
             sortOrderSubmenu.prepareSortOrder(SortOrder.yearSortOrder)
         }

--- a/app/src/main/java/com/mardous/booming/helper/ShuffleHelper.kt
+++ b/app/src/main/java/com/mardous/booming/helper/ShuffleHelper.kt
@@ -111,7 +111,7 @@ object ShuffleHelper {
 
     private fun addSongsToList(songs: List<Song>, destination: MutableList<Song>, sortKey: String?) {
         val songList = when {
-            sortKey != null -> songs.sortedSongs(sortKey, false)
+            sortKey != null -> songs.sortedSongs(sortKey, descending = false, ignoreArticles = true)
             else -> songs.shuffled()
         }
         destination.addAll(songList)

--- a/app/src/main/java/com/mardous/booming/util/sort/SortOrder.kt
+++ b/app/src/main/java/com/mardous/booming/util/sort/SortOrder.kt
@@ -38,6 +38,10 @@ class SortOrder(
         get() = sharedPreferences.getBoolean("${id}_descending", defaultDescending)
         set(value) = sharedPreferences.edit { putBoolean("${id}_descending", value) }
 
+    var ignoreArticles: Boolean
+        get() = sharedPreferences.getBoolean("${id}_sort_order_ignore_articles", true)
+        set(value) = sharedPreferences.edit { putBoolean("${id}_sort_order_ignore_articles", value) }
+
     companion object : KoinComponent {
         private val preferences: SharedPreferences by inject()
         private val sortOrderMap = hashMapOf<String, SortOrder>()

--- a/app/src/main/res/menu/menu_album_song_sort_order.xml
+++ b/app/src/main/res/menu/menu_album_song_sort_order.xml
@@ -15,4 +15,8 @@
         android:id="@+id/action_sort_order_descending"
         android:title="@string/sort_order_descending"
         android:checkable="true"/>
+    <item
+        android:id="@+id/action_sort_order_ignore_articles"
+        android:title="@string/sort_order_ignore_articles"
+        android:checkable="true"/>
 </menu>

--- a/app/src/main/res/menu/menu_artist_album_sort_order.xml
+++ b/app/src/main/res/menu/menu_artist_album_sort_order.xml
@@ -15,4 +15,8 @@
         android:id="@+id/action_sort_order_descending"
         android:title="@string/sort_order_descending"
         android:checkable="true"/>
+    <item
+        android:id="@+id/action_sort_order_ignore_articles"
+        android:title="@string/sort_order_ignore_articles"
+        android:checkable="true"/>
 </menu>

--- a/app/src/main/res/menu/menu_artist_song_sort_order.xml
+++ b/app/src/main/res/menu/menu_artist_song_sort_order.xml
@@ -21,4 +21,8 @@
         android:id="@+id/action_sort_order_descending"
         android:title="@string/sort_order_descending"
         android:checkable="true"/>
+    <item
+        android:id="@+id/action_sort_order_ignore_articles"
+        android:title="@string/sort_order_ignore_articles"
+        android:checkable="true"/>
 </menu>

--- a/app/src/main/res/menu/menu_genre_detail.xml
+++ b/app/src/main/res/menu/menu_genre_detail.xml
@@ -44,6 +44,14 @@
                     android:id="@+id/action_sort_order_duration"
                     android:title="@string/sort_order_duration"/>
             </group>
+            <item
+                android:id="@+id/action_sort_order_descending"
+                android:title="@string/sort_order_descending"
+                android:checkable="true"/>
+            <item
+                android:id="@+id/action_sort_order_ignore_articles"
+                android:title="@string/sort_order_ignore_articles"
+                android:checkable="true"/>
         </menu>
     </item>
 </menu>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -235,6 +235,7 @@
     <string name="sort_order_last_played_date">Fecha de última reproducción</string>
     <string name="sort_order_track_list">Número de pista</string>
     <string name="sort_order_descending">Descendente</string>
+    <string name="sort_order_ignore_articles">Ignorar artículos</string>
     <string name="action_set_as_ringtone">Usar como tono de llamada</string>
     <string name="x_will_be_set_as_ringtone"><![CDATA[Se usará <b>%s</b> como tono de llamada]]></string>
     <string name="x_has_been_set_as_ringtone">Se configuró %s como tono</string>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -10,6 +10,7 @@
     <item name="action_sort_order_number_of_albums" type="id"/>
     <item name="action_sort_order_number_of_songs" type="id"/>
     <item name="action_sort_order_descending" type="id"/>
+    <item name="action_sort_order_ignore_articles" type="id"/>
 
     <item name="action_album_artist" type="id"/>
     <item name="action_new_playlist" type="id"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="sort_order_last_played_date">Last played date</string>
     <string name="sort_order_track_list">Track list</string>
     <string name="sort_order_descending">Descending</string>
+    <string name="sort_order_ignore_articles">Ignore articles</string>
     <string name="action_set_as_ringtone">Set as ringtone</string>
     <string name="x_will_be_set_as_ringtone"><![CDATA[Will set <b>%s</b> as your ringtone]]></string>
     <string name="x_has_been_set_as_ringtone">Set %s as your ringtone</string>


### PR DESCRIPTION
This commit introduces a new feature that allows users to ignore articles (e.g., "the", "a", "an") when sorting lists of songs, artists, albums, and genres.

The following changes were made:
- Added a new "Ignore articles" option to the sort order menus for songs, artists, albums, and genres.
- Updated the `SortOrder` class to store and retrieve the "Ignore articles" preference.
- Modified the sorting logic in `SortExt.kt` to strip leading articles from strings before comparison if the "Ignore articles" option is enabled. This is done using a predefined list of articles for common languages.
- Updated the UI in various fragments to include the new sort option and handle its state.

This is related to #19 