### PR TITLE
Fixed App Crash and Shuffle

### DIFF
--- a/app/src/main/java/com/mardous/booming/fragments/songs/SongListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/songs/SongListFragment.kt
@@ -62,7 +62,7 @@ class SongListFragment : AbsRecyclerViewCustomGridSizeFragment<SongAdapter, Grid
     override fun onShuffleClicked() {
         super.onShuffleClicked()
         adapter?.dataSet?.let { songs ->
-            playerViewModel.openQueue(songs, shuffleMode = Playback.ShuffleMode.On)
+            playerViewModel.openAndShuffleQueue(songs, shuffleMode = Playback.ShuffleMode.On)
         }
     }
 

--- a/app/src/main/java/com/mardous/booming/viewmodels/lyrics/model/LyricsResult.kt
+++ b/app/src/main/java/com/mardous/booming/viewmodels/lyrics/model/LyricsResult.kt
@@ -39,11 +39,11 @@ class LyricsResult(
     val hasSyncedLyrics: Boolean get() = syncedLyrics.content?.hasContent == true
     val isEmpty: Boolean get() = !hasPlainLyrics && !hasSyncedLyrics
 
-    init {
-        check(sources.distinctBy { it.applicableButtonId }.size == 2) {
-            "Applicable IDs must be unique"
-        }
-    }
+//    init {
+//        check(sources.distinctBy { it.applicableButtonId }.size == 2) {
+//            "Applicable IDs must be unique"
+//        }
+//    }
 
     companion object {
         val Empty = LyricsResult(-1)

--- a/app/src/main/java/com/mardous/booming/viewmodels/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/viewmodels/player/PlayerViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 @OptIn(FlowPreview::class)
 class PlayerViewModel(
@@ -184,6 +185,14 @@ class PlayerViewModel(
         shuffleMode: Playback.ShuffleMode? = null
     ) = viewModelScope.launch(IO) {
         queueManager.open(queue, position, startPlaying, shuffleMode)
+    }
+
+    fun openAndShuffleQueue(
+        queue: List<Song>,
+        startPlaying: Boolean = true,
+        shuffleMode: Playback.ShuffleMode? = null
+    ) = viewModelScope.launch(IO) {
+        queueManager.open(queue, Random.Default.nextInt(queue.size), startPlaying, shuffleMode)
     }
 
     fun openShuffle(


### PR DESCRIPTION
this update fixes
-the app crash caused by LyricsResult
-the shuffle button on the songs list always starting at the first song in the list when starting new shuffle queue