### PR TITLE
Fix Kotlin annotation targeting warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,7 @@ android {
 kotlin {
     compilerOptions {
         optIn.add("kotlin.RequiresOptIn")
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
     jvmToolchain(21)
 }


### PR DESCRIPTION
Add -Xannotation-default-target=param-property compiler flag to resolve KT-73255 warnings about annotation targeting in constructor parameters.