### PR TITLE
Fix/shuffle mutex

### DIFF
--- a/app/src/main/java/com/mardous/booming/database/BoomingDatabase.kt
+++ b/app/src/main/java/com/mardous/booming/database/BoomingDatabase.kt
@@ -44,9 +44,9 @@ abstract class BoomingDatabase : RoomDatabase() {
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE PlaylistEntity ADD COLUMN custom_cover_uri TEXT")
-                database.execSQL("ALTER TABLE PlaylistEntity ADD COLUMN description TEXT")
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE PlaylistEntity ADD COLUMN custom_cover_uri TEXT")
+                db.execSQL("ALTER TABLE PlaylistEntity ADD COLUMN description TEXT")
             }
         }
     }


### PR DESCRIPTION
This PR adds a coroutine Mutex to the PlayerViewModel to prevent concurrent shuffle actions. Previously, rapidly spamming the shuffle button could cause the app’s UI (artwork carousel, etc.) to break or behave unexpectedly. Now, only one shuffle action can run at a time, ensuring the queue and UI stay in sync