### PR TITLE
fix queue position bug when swiping album cover to change songs

### DIFF
--- a/app/src/main/java/com/mardous/booming/fragments/player/PlayerAlbumCoverFragment.kt
+++ b/app/src/main/java/com/mardous/booming/fragments/player/PlayerAlbumCoverFragment.kt
@@ -107,7 +107,6 @@ class PlayerAlbumCoverFragment : Fragment(R.layout.fragment_player_album_cover),
     @SuppressLint("ClickableViewAccessibility")
     override fun onStart() {
         super.onStart()
-        viewPager.addOnPageChangeListener(this)
         viewPager.setOnTouchListener { _, event ->
             val adapter = viewPager.adapter ?: return@setOnTouchListener false
             if (!isAdded || adapter.count == 0) {
@@ -141,6 +140,7 @@ class PlayerAlbumCoverFragment : Fragment(R.layout.fragment_player_album_cover),
     }
 
     private fun setupEventObserver() {
+        viewPager.addOnPageChangeListener(this)
         viewLifecycleOwner.launchAndRepeatWithViewLifecycle {
             playerViewModel.playingQueueFlow.collect { playingQueue ->
                 _binding?.viewPager?.let { pager ->


### PR DESCRIPTION
when " viewPager.addOnPageChangeListener(this)" is in onStart it can have an issue where the queue moves by multiple songs instead of a single song when swiping on the album cover in the player after opening app from background. this fixes it by moving it from onStart which gets called during the onResume lifecycle and puts it into the setupEventObserver which is only called during the onViewCreated method.