### PR TITLE
Fix: text visibility on Full Cover theme

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/screen/player/styles/fullcoverstyle/FullCoverPlayerFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/player/styles/fullcoverstyle/FullCoverPlayerFragment.kt
@@ -43,6 +43,7 @@ import com.mardous.booming.ui.component.views.getPlaceholderDrawable
 import com.mardous.booming.ui.screen.player.PlayerColorScheme
 import com.mardous.booming.ui.screen.player.PlayerColorSchemeMode
 import com.mardous.booming.ui.screen.player.PlayerTintTarget
+import com.mardous.booming.ui.screen.player.iconButtonTintTarget
 import com.mardous.booming.ui.screen.player.tintTarget
 import com.mardous.booming.util.Preferences
 
@@ -123,13 +124,28 @@ class FullCoverPlayerFragment : AbsPlayerFragment(R.layout.fragment_full_cover_p
     }
 
     override fun getTintTargets(scheme: PlayerColorScheme): List<PlayerTintTarget> {
-        val oldMaskColor = binding.mask.backgroundTintList?.defaultColor
-            ?: Color.TRANSPARENT
-        return mutableListOf(
-            binding.mask.tintTarget(oldMaskColor, scheme.surfaceColor)
-        ).also {
-            it.addAll(playerControlsFragment.getTintTargets(scheme))
+        val targets = mutableListOf<PlayerTintTarget>()
+
+        val oldLabelColor = binding.nextSongLabel.currentTextColor
+        targets.add(binding.nextSongLabel.tintTarget(oldLabelColor, scheme.secondaryTextColor))
+
+        val oldTextColor = binding.nextSongText.currentTextColor
+        targets.add(binding.nextSongText.tintTarget(oldTextColor, scheme.primaryTextColor))
+
+        val oldCaretColor = binding.close.iconTint?.defaultColor ?: Color.WHITE
+        targets.add(binding.close.iconButtonTintTarget(oldCaretColor, scheme.primaryTextColor))
+
+        val oldMaskColor = binding.mask.backgroundTintList?.defaultColor ?: Color.TRANSPARENT
+        targets.add(binding.mask.tintTarget(oldMaskColor, scheme.surfaceColor))
+
+        val oldTopMaskColor = binding.topMask.backgroundTintList?.defaultColor ?: Color.TRANSPARENT
+        targets.add(binding.topMask.tintTarget(oldTopMaskColor, scheme.surfaceColor))
+
+        playerControlsFragment.let {
+            targets.addAll(it.getTintTargets(scheme))
         }
+
+        return targets
     }
 
     override fun onIsFavoriteChanged(isFavorite: Boolean, withAnimation: Boolean) {

--- a/app/src/main/res/drawable/shadow_down_gradient.xml
+++ b/app/src/main/res/drawable/shadow_down_gradient.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="270"
+        android:endColor="@android:color/transparent"
+        android:centerColor="#80000000"
+        android:startColor="@android:color/black" />
+</shape>

--- a/app/src/main/res/layout-land/fragment_full_cover_player.xml
+++ b/app/src/main/res/layout-land/fragment_full_cover_player.xml
@@ -28,6 +28,15 @@
         android:background="@drawable/shadow_up_gradient"
         tools:backgroundTint="?colorPrimary"/>
 
+    <View
+        android:id="@+id/top_mask"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:background="@drawable/shadow_down_gradient"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <LinearLayout
         android:id="@+id/toolbar_container"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_full_cover_player.xml
+++ b/app/src/main/res/layout/fragment_full_cover_player.xml
@@ -28,6 +28,15 @@
         android:background="@drawable/shadow_up_gradient"
         tools:backgroundTint="?colorPrimary"/>
 
+    <View
+        android:id="@+id/top_mask"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:background="@drawable/shadow_down_gradient"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <LinearLayout
         android:id="@+id/toolbar_container"
         android:layout_width="match_parent"
@@ -48,7 +57,6 @@
                 android:layout_marginStart="8dp"
                 android:contentDescription="@string/close_action"
                 app:icon="@drawable/ic_keyboard_arrow_down_24dp"
-                app:iconTint="@android:color/white"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"/>
@@ -70,7 +78,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
                 android:textAppearance="?textAppearanceBody2"
-                android:textColor="@android:color/darker_gray"
+                android:textColor="?attr/colorOnSurfaceVariant"
                 android:text="@string/next_song_label"
                 app:layout_constrainedWidth="true"
                 app:layout_constraintTop_toTopOf="parent"
@@ -85,7 +93,7 @@
                 android:singleLine="true"
                 android:ellipsize="end"
                 android:textAppearance="?textAppearanceBody1"
-                android:textColor="@android:color/white"
+                android:textColor="?attr/colorOnSurface"
                 android:textStyle="bold"
                 app:layout_constrainedWidth="true"
                 app:layout_constraintTop_toBottomOf="@+id/next_song_label"


### PR DESCRIPTION
Made the text at the top of the screen Material You compliant for better readability on bright/white album covers. Also added a gradient behind the text to make it match the bottom.