### PR TITLE
Fix: launcher shortcuts shuffle mode

### DIFF
--- a/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
@@ -735,15 +735,14 @@ class PlaybackService :
         withContext(Main) {
             if (songs.isNotEmpty()) {
                 val shuffle = intent.getBooleanExtra(EXTRA_SHUFFLE_MODE, false)
-                player.setMediaItems(songs.toMediaItems())
+                val mediaItems = songs.toMediaItems().toMutableList()
+
                 if (shuffle) {
-                    player.shuffleModeEnabled = true
-                    if (player.mediaItemCount > 0) {
-                        player.seekToDefaultPosition((0 until player.mediaItemCount).random())
-                    }
-                } else {
-                    player.shuffleModeEnabled = false
+                    mediaItems.shuffle()
                 }
+
+                player.setMediaItems(mediaItems)
+                player.shuffleModeEnabled = shuffle
                 player.prepare()
                 player.play()
             } else {


### PR DESCRIPTION
Made the shuffle mode toggle actually shuffle the playlists before playing instead of starting the playlists and just enabling shuffle, which did not actually shuffle the playlists.