### PR TITLE
Fix: padding of player style title

### DIFF
--- a/app/src/main/res/layout/preference_dialog_now_playing_screen.xml
+++ b/app/src/main/res/layout/preference_dialog_now_playing_screen.xml
@@ -18,7 +18,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="top"
-            android:paddingTop="16dp"/>
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"/>
 
     </androidx.viewpager.widget.ViewPager>
 


### PR DESCRIPTION
The title of the Now Playing styles was a bit too close to the screenshot.

## Summary by Sourcery

Bug Fixes:
- Add 16dp bottom padding to the Now Playing style title view for proper spacing