### PR TITLE
Refactor: queue gesture toggle

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsPlayerFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsPlayerFragment.kt
@@ -265,7 +265,9 @@ abstract class AbsPlayerFragment(@LayoutRes layoutRes: Int) : Fragment(layoutRes
                     }
 
                     GestureType.Fling.DIRECTION_UP -> {
-                        findNavController().navigate(R.id.nav_queue)
+                        if (Preferences.isSwipeUpQueue) {
+                            findNavController().navigate(R.id.nav_queue)
+                        }
                         true
                     }
 

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -431,6 +431,10 @@ object Preferences : KoinComponent {
         get() = preferences.getBoolean(SWIPE_ANYWHERE, false)
         set(value) = preferences.edit { putBoolean(SWIPE_ANYWHERE, value) }
 
+    var isSwipeUpQueue: Boolean
+        get() = preferences.getBoolean(SWIPE_UP_QUEUE, false)
+        set(value) = preferences.edit { putBoolean(SWIPE_UP_QUEUE, value) }
+
     var isShowNextSong: Boolean
         get() = preferences.getBoolean(DISPLAY_NEXT_SONG, true)
         set(value) = preferences.edit { putBoolean(DISPLAY_NEXT_SONG, value) }
@@ -639,6 +643,7 @@ const val NEXT_SLEEP_TIMER_ELAPSED_REALTIME = "next_sleep_timer_elapsed_real_tim
 const val SLEEP_TIMER_FINISH_SONG = "sleep_timer_finish_music"
 const val HIERARCHY_FOLDER_VIEW = "hierarchy_folder_view"
 const val SWIPE_ANYWHERE = "swipe_anywhere"
+const val SWIPE_UP_QUEUE = "swipe_up_queue"
 const val DISPLAY_NEXT_SONG = "display_next_song"
 const val LOCKED_QUEUE = "locked_queue"
 const val LOCKED_PLAYLISTS = "locked_playlists"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -702,6 +702,8 @@
     <string name="animate_controls_summary">It\'s played when opening the player panel.</string>
     <string name="swipe_anywhere_title">Swipe anywhere to change song</string>
     <string name="swipe_anywhere_summary">Swipe left or right on any empty area of the now playing screen to switch between songs.</string>
+    <string name="swipe_up_queue_title">Swipe upwards to open queue</string>
+    <string name="swipe_up_queue_summary">Swipe upwards on any empty area of the now playing screen to open the playing queue.</string>
     <string name="display_album_name_title">Display album name</string>
     <string name="display_extra_info_title">Display extra info</string>
     <string name="display_extra_info_summary">Display extra info about the song, like bitrate, format, sampling rate, etc.</string>

--- a/app/src/main/res/xml/preferences_screen_now_playing.xml
+++ b/app/src/main/res/xml/preferences_screen_now_playing.xml
@@ -95,6 +95,15 @@
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="true"
+            app:title="@string/swipe_up_queue_title"
+            app:summary="@string/swipe_up_queue_summary"
+            app:defaultValue="false"
+            app:layout="@layout/list_item_view"
+            app:widgetLayout="@layout/preference_switch"
+            app:key="swipe_up_queue" />
+
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="true"
             app:title="@string/swipe_album_cover_title"
             app:summary="@string/swipe_album_cover_summary"
             app:defaultValue="true"


### PR DESCRIPTION
### Summary

Separated the toggle for the queue gesture. Wasn't really necessary, but it can be useful for those that only want the swipe up gesture to open the queue.

## Summary by Sourcery

Add separate user preference to enable or disable the swipe-up gesture for opening the playing queue

New Features:
- Introduce a new SwitchPreference for the swipe-up queue gesture in the Now Playing settings
- Add a corresponding preference field (SWIPE_UP_QUEUE) in Preferences util and constants

Enhancements:
- Modify the player fragment to only navigate to the queue when the swipe-up setting is enabled