### PR TITLE
Add Song Tab to Android Auto

### DIFF
--- a/app/src/main/java/com/mardous/booming/playback/library/LibraryProvider.kt
+++ b/app/src/main/java/com/mardous/booming/playback/library/LibraryProvider.kt
@@ -158,8 +158,8 @@ class LibraryProvider(private val repository: Repository) {
                                 .setMediaId(MediaIDs.SONGS)
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
-                                        .setMediaType(MediaMetadata.MEDIA_TYPE_MIXED)
-                                        .setIsBrowsable(false)
+                                        .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_MIXED)
+                                        .setIsBrowsable(true)
                                         .setIsPlayable(false)
                                         .setTitle(resources.getString(categoryInfo.category.titleRes))
                                         .build()


### PR DESCRIPTION
Added Song Tab to Android Auto

NOTE: this only plays the selected song. it will not create a queue and play the queue. this still needs to be implemented

## Summary by Sourcery

New Features:
- Introduce a Songs category in the Android Auto library browser to allow direct song selection and playback