### PR TITLE
fix album cover horizontal flip and vertical flip

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/component/transform/HorizontalFlipTransformation.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/transform/HorizontalFlipTransformation.kt
@@ -23,33 +23,34 @@ import kotlin.math.abs
 class HorizontalFlipTransformation : ViewPager.PageTransformer {
     override fun transformPage(page: View, position: Float) {
         page.apply {
-            page.translationX = -position * page.width
-            page.cameraDistance = 20000f
+            translationX = -position * width
+            cameraDistance = 100000f
 
             if (position < 0.5 && position > -0.5) {
-                page.isVisible = true
+                isVisible = true
             } else {
-                page.isInvisible = true
+                isInvisible = true
             }
 
             when {
                 position < -1 -> {     // [-Infinity,-1)
                     // This page is way off-screen to the left.
-                    page.alpha = 0f
+                    alpha = 0f
                 }
                 position <= 0 -> {    // [-1,0]
-                    page.alpha = 1f
-                    page.rotationX = 180 * (1 - abs(position) + 1)
+                    alpha = 1f
+                    rotationY = 180 * (1 - abs(position) + 1)
                 }
                 position <= 1 -> {    // (0,1]
-                    page.alpha = 1f
-                    page.rotationX = -180 * (1 - abs(position) + 1)
+                    alpha = 1f
+                    rotationY = -180 * (1 - abs(position) + 1)
                 }
                 else -> {    // (1,+Infinity]
                     // This page is way off-screen to the right.
-                    page.alpha = 0f
+                    alpha = 0f
                 }
             }
         }
+
     }
 }

--- a/app/src/main/java/com/mardous/booming/ui/component/transform/VerticalFlipTransformation.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/transform/VerticalFlipTransformation.kt
@@ -23,34 +23,33 @@ import kotlin.math.abs
 class VerticalFlipTransformation : ViewPager.PageTransformer {
     override fun transformPage(page: View, position: Float) {
         page.apply {
-            translationX = -position * width
-            cameraDistance = 100000f
+            page.translationX = -position * page.width
+            page.cameraDistance = 20000f
 
             if (position < 0.5 && position > -0.5) {
-                isVisible = true
+                page.isVisible = true
             } else {
-                isInvisible = true
+                page.isInvisible = true
             }
 
             when {
                 position < -1 -> {     // [-Infinity,-1)
                     // This page is way off-screen to the left.
-                    alpha = 0f
+                    page.alpha = 0f
                 }
                 position <= 0 -> {    // [-1,0]
-                    alpha = 1f
-                    rotationY = 180 * (1 - abs(position) + 1)
+                    page.alpha = 1f
+                    page.rotationX = 180 * (1 - abs(position) + 1)
                 }
                 position <= 1 -> {    // (0,1]
-                    alpha = 1f
-                    rotationY = -180 * (1 - abs(position) + 1)
+                    page.alpha = 1f
+                    page.rotationX = -180 * (1 - abs(position) + 1)
                 }
                 else -> {    // (1,+Infinity]
                     // This page is way off-screen to the right.
-                    alpha = 0f
+                    page.alpha = 0f
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
fix album cover horizontal flip and vertical flip

## Summary by Sourcery

Fix album cover flip transformations by correcting rotation axes, tuning camera distances, and unifying property access style

Bug Fixes:
- Use rotationY for horizontal flips and rotationX for vertical flips to restore correct flip behavior

Enhancements:
- Adjust cameraDistance values for improved perspective on both flip transformations
- Standardize property access and scoping in horizontal and vertical transformation classes