### PR TITLE
Reopen Player When Equalizer is Closed

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsPlayerFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsPlayerFragment.kt
@@ -79,6 +79,7 @@ import com.mardous.booming.ui.dialogs.songs.DeleteSongsDialog
 import com.mardous.booming.ui.dialogs.songs.ShareSongDialog
 import com.mardous.booming.ui.screen.MainActivity
 import com.mardous.booming.ui.screen.equalizer.EqualizerFragment
+import com.mardous.booming.ui.screen.equalizer.EqualizerFragmentArgs
 import com.mardous.booming.ui.screen.library.LibraryViewModel
 import com.mardous.booming.ui.screen.lyrics.LyricsEditorFragmentArgs
 import com.mardous.booming.ui.screen.lyrics.LyricsFragment
@@ -248,7 +249,14 @@ abstract class AbsPlayerFragment(@LayoutRes layoutRes: Int) : Fragment(layoutRes
                 if (currentFragment(R.id.fragment_container) is EqualizerFragment) {
                     (activity as? MainActivity)?.collapsePanel()
                 } else {
-                    goToDestination(requireActivity(), R.id.nav_equalizer)
+                    goToDestination(
+                        activity = requireActivity(),
+                        destinationId = R.id.nav_equalizer,
+                        args = EqualizerFragmentArgs.Builder()
+                            .setFromPlayer(true)
+                            .build()
+                            .toBundle()
+                    )
                 }
                 true
             }

--- a/app/src/main/java/com/mardous/booming/ui/screen/equalizer/EqualizerFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/equalizer/EqualizerFragment.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.mardous.booming.extensions.materialSharedAxis
 import com.mardous.booming.ui.screen.MainActivity
 import com.mardous.booming.ui.screen.library.LibraryViewModel
@@ -33,6 +34,8 @@ import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class EqualizerFragment : Fragment() {
+
+    private val arguments: EqualizerFragmentArgs by navArgs()
 
     private val libraryViewModel: LibraryViewModel by activityViewModel()
     private val equalizerViewModel: EqualizerViewModel by viewModel()
@@ -63,7 +66,7 @@ class EqualizerFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        if (playerViewModel.queue.isNotEmpty()) {
+        if (arguments.fromPlayer && playerViewModel.queue.isNotEmpty()) {
             (activity as? MainActivity)?.expandPanel()
         }
     }

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -179,7 +179,12 @@
     <fragment
         android:id="@+id/nav_equalizer"
         android:name="com.mardous.booming.ui.screen.equalizer.EqualizerFragment"
-        android:label="EqualizerFragment"/>
+        android:label="EqualizerFragment">
+        <argument
+            android:name="from_player"
+            app:argType="boolean"
+            android:defaultValue="false" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_settings"


### PR DESCRIPTION
Reopen Player When Equalizer is Closed

## Summary by Sourcery

Enhancements:
- Restore the player panel on equalizer fragment destruction when the playback queue is not empty.