### PR TITLE
ci(release): fix path mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: apk-${{ matrix.variant }}-release
-          path: app/build/outputs/apk/*/release/*-release.apk
+          path: app/build/outputs/apk/${{ matrix.variant }}/release/*.apk
 
   publish-release:
     needs: build
@@ -77,6 +77,4 @@ jobs:
         with:
           prerelease: ${{ steps.prerelease.outputs.value }}
           generate_release_notes: true
-          files: |
-            release-apks/*/release/*-fdroid-release.apk
-            release-apks/*/release/*-normal-release.apk
+          files: release-apks/*.apk


### PR DESCRIPTION
This caused the release to be posted first without any files attached. I noticed this when you released 1.2.1 but there were no files attached for 15m long (I believe). This should PR fix that problem.

## Summary by Sourcery

Fix release workflow paths so built APKs are correctly uploaded as artifacts and attached to GitHub releases.

Build:
- Correct APK artifact upload path in the release workflow to match matrix variants.
- Simplify release asset file glob to attach all APKs from the consolidated release directory.