### PR TITLE
Hack-fix the behavior which prevents opening queue with gesture when lyrics enabled

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/screen/player/cover/CoverLyricsFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/player/cover/CoverLyricsFragment.kt
@@ -56,7 +56,10 @@ class CoverLyricsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val gesturesListener = (parentFragment?.parentFragment as? AbsPlayerFragment)
+        val gesturesListener = generateSequence(parentFragment) { it.parentFragment }
+            .filterIsInstance<AbsPlayerFragment>()
+            .firstOrNull()
+
         if (gesturesListener != null) {
             gesturesController = PlayerGesturesController(
                 context = view.context,
@@ -72,6 +75,7 @@ class CoverLyricsFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        view?.setOnTouchListener(null)
         gesturesController?.release()
         gesturesController = null
         super.onDestroyView()

--- a/app/src/main/java/com/mardous/booming/ui/screen/player/cover/CoverLyricsFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/player/cover/CoverLyricsFragment.kt
@@ -9,11 +9,14 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import com.mardous.booming.R
 import com.mardous.booming.extensions.currentFragment
+import com.mardous.booming.ui.component.base.AbsPlayerFragment
 import com.mardous.booming.ui.component.base.goToDestination
 import com.mardous.booming.ui.screen.MainActivity
 import com.mardous.booming.ui.screen.lyrics.CoverLyricsScreen
 import com.mardous.booming.ui.screen.lyrics.LyricsFragment
 import com.mardous.booming.ui.screen.lyrics.LyricsViewModel
+import com.mardous.booming.ui.screen.player.PlayerGesturesController
+import com.mardous.booming.ui.screen.player.PlayerGesturesController.GestureType
 import com.mardous.booming.ui.screen.player.PlayerViewModel
 import com.mardous.booming.ui.theme.BoomingMusicTheme
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
@@ -22,6 +25,8 @@ class CoverLyricsFragment : Fragment() {
 
     private val lyricsViewModel: LyricsViewModel by activityViewModel()
     private val playerViewModel: PlayerViewModel by activityViewModel()
+
+    private var gesturesController: PlayerGesturesController? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -47,5 +52,28 @@ class CoverLyricsFragment : Fragment() {
                 }
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val gesturesListener = (parentFragment?.parentFragment as? AbsPlayerFragment)
+        if (gesturesListener != null) {
+            gesturesController = PlayerGesturesController(
+                context = view.context,
+                acceptedGestures = setOf(
+                    GestureType.Fling(GestureType.Fling.DIRECTION_UP),
+                    GestureType.Fling(GestureType.Fling.DIRECTION_LEFT),
+                    GestureType.Fling(GestureType.Fling.DIRECTION_RIGHT)
+                ),
+                listener = gesturesListener
+            )
+            view.setOnTouchListener(gesturesController)
+        }
+    }
+
+    override fun onDestroyView() {
+        gesturesController?.release()
+        gesturesController = null
+        super.onDestroyView()
     }
 }


### PR DESCRIPTION
CoverLyricsFragment was displayed on top of the cover and consumed all touch events so they weren't sent to AbsPlayerFragment. The new gesturesController now handles gesture actions and passes them, effectively fixing the bug. Although I probably woudn't call it a proper fix, I think it'll do for now. Fixes #221.

## Summary by Sourcery

Bug Fixes:
- Restore swipe gestures (e.g., to open the queue) when the lyrics overlay is visible by delegating touch events to the shared player gesture controller.