### PR TITLE
Remove Emoji from sections with no elements

### DIFF
--- a/app/src/main/res/layout/fragment_main_recycler.xml
+++ b/app/src/main/res/layout/fragment_main_recycler.xml
@@ -35,14 +35,6 @@
         tools:visibility="visible">
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/emptyEmoji"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:text="@string/empty_text_emoji"
-            android:textAppearance="?textAppearanceHeadline3"/>
-
-        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/emptyText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -5,7 +5,6 @@
 
 	<string name="mardous" translatable="false">Christians Martínez A.</string>
 
-	<string name="empty_text_emoji" translatable="false">&#128561;</string>
     <string name="instrumental_identifiers" translatable="false">(Instrumental)</string>
 
     <string name="speed_0_5x" translatable="false">0.5x</string>


### PR DESCRIPTION
Fixes #325

## Summary by Sourcery

Bug Fixes:
- Stop displaying an emoji in sections with no elements by removing the emoji view from the empty-state layout.