### PR TITLE
Add play count sorting

### DIFF
--- a/app/src/main/java/com/mardous/booming/MainModule.kt
+++ b/app/src/main/java/com/mardous/booming/MainModule.kt
@@ -26,6 +26,7 @@ import com.mardous.booming.core.audio.AudioOutputObserver
 import com.mardous.booming.data.local.AlbumCoverSaver
 import com.mardous.booming.data.local.EditTarget
 import com.mardous.booming.data.local.MediaStoreWriter
+import com.mardous.booming.data.local.cache.PlayCountCache
 import com.mardous.booming.data.local.repository.AlbumRepository
 import com.mardous.booming.data.local.repository.ArtistRepository
 import com.mardous.booming.data.local.repository.GenreRepository
@@ -235,6 +236,10 @@ private val dataModule = module {
             specialRepository = get()
         )
     } bind SearchRepository::class
+
+    single(createdAtStart = true) {
+        PlayCountCache(playCountDao = get())
+    }
 
     single {
         RealSmartRepository(

--- a/app/src/main/java/com/mardous/booming/core/model/sort/SortItem.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/sort/SortItem.kt
@@ -72,6 +72,12 @@ sealed class KeySortItem(id: Int, title: Int, val key: SortKey)
         R.string.sort_order_file_name,
         SortKey.FileName
     )
+
+    object MostPlayed : KeySortItem(
+        R.id.action_sort_order_play_count,
+        R.string.sort_order_play_count,
+        SortKey.MostPlayed
+    )
 }
 
 object DescendingItem : SortItem(

--- a/app/src/main/java/com/mardous/booming/core/model/sort/SortKey.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/sort/SortKey.kt
@@ -11,5 +11,6 @@ enum class SortKey(val value: String) {
     DateModified("modified_key"),
     SongCount("songs_key"),
     AlbumCount("albums_key"),
-    FileName("file_name_key")
+    FileName("file_name_key"),
+    MostPlayed("most_played_key")
 }

--- a/app/src/main/java/com/mardous/booming/core/sort/SortMode.kt
+++ b/app/src/main/java/com/mardous/booming/core/sort/SortMode.kt
@@ -10,6 +10,7 @@ import com.mardous.booming.core.model.sort.DescendingItem
 import com.mardous.booming.core.model.sort.KeySortItem
 import com.mardous.booming.core.model.sort.SortItem
 import com.mardous.booming.core.model.sort.SortKey
+import com.mardous.booming.data.local.cache.playCount
 import com.mardous.booming.data.local.room.PlaylistWithSongs
 import com.mardous.booming.data.model.*
 import com.mardous.booming.extensions.media.albumArtistName
@@ -129,6 +130,7 @@ sealed class SongSortMode(
             KeySortItem.DateAdded,
             KeySortItem.DateModified,
             KeySortItem.FileName,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -140,6 +142,7 @@ sealed class SongSortMode(
             KeySortItem.Title,
             KeySortItem.Track,
             KeySortItem.Duration,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -153,6 +156,7 @@ sealed class SongSortMode(
             KeySortItem.Duration,
             KeySortItem.Year,
             KeySortItem.DateAdded,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -165,6 +169,7 @@ sealed class SongSortMode(
             KeySortItem.Artist,
             KeySortItem.Album,
             KeySortItem.Duration,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -177,6 +182,7 @@ sealed class SongSortMode(
             KeySortItem.Artist,
             KeySortItem.Album,
             KeySortItem.Duration,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -192,6 +198,7 @@ sealed class SongSortMode(
             KeySortItem.DateAdded,
             KeySortItem.DateModified,
             KeySortItem.FileName,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -225,6 +232,7 @@ sealed class SongSortMode(
             SortKey.DateAdded -> sortedWith(compareBy { it.dateAdded })
             SortKey.DateModified -> sortedWith(compareBy { it.rawDateModified })
             SortKey.FileName -> sortedWith(compareBy { it.fileName })
+            SortKey.MostPlayed -> sortedWith(compareBy { it.playCount })
             else -> this
         }
         return if (selectedDescending) songs.reversed() else songs
@@ -246,6 +254,7 @@ sealed class AlbumSortMode(
             KeySortItem.Year,
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -258,6 +267,7 @@ sealed class AlbumSortMode(
             KeySortItem.Year,
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -270,6 +280,7 @@ sealed class AlbumSortMode(
             KeySortItem.Year,
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -287,6 +298,7 @@ sealed class AlbumSortMode(
             SortKey.Year -> sortedWith(compareBy { it.year })
             SortKey.SongCount -> sortedWith(compareBy { it.songCount })
             SortKey.DateAdded -> sortedWith(compareBy { it.dateAdded })
+            SortKey.MostPlayed -> sortedWith(compareBy { it.playCount })
             else -> this
         }
         return if (selectedDescending) albums.reversed() else albums
@@ -306,6 +318,7 @@ sealed class ArtistSortMode(
             KeySortItem.Title,
             KeySortItem.SongCount,
             KeySortItem.AlbumCount,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -317,6 +330,7 @@ sealed class ArtistSortMode(
             })
             SortKey.SongCount -> sortedWith(compareBy({ it.songCount }, { it.name.normalize() }))
             SortKey.AlbumCount -> sortedWith(compareBy({ it.albumCount }, { it.name.normalize() }))
+            SortKey.MostPlayed -> sortedWith(compareBy { it.playCount })
             else -> this
         }
         return if (selectedDescending) artists.reversed() else artists
@@ -335,6 +349,7 @@ sealed class GenreSortMode(
         items = listOf(
             KeySortItem.Title,
             KeySortItem.SongCount,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -346,6 +361,7 @@ sealed class GenreSortMode(
             })
 
             SortKey.SongCount -> sortedWith(compareBy { it.songCount })
+            SortKey.MostPlayed -> sortedWith(compareBy { it.playCount })
             else -> this
         }
         return if (selectedDescending) genres.reversed() else genres
@@ -364,6 +380,7 @@ sealed class YearSortMode(
         items = listOf(
             KeySortItem.Year,
             KeySortItem.SongCount,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -372,6 +389,7 @@ sealed class YearSortMode(
         val years = when (selectedKey) {
             SortKey.Year -> sortedWith(compareBy { it.year })
             SortKey.SongCount -> sortedWith(compareBy { it.songCount })
+            SortKey.MostPlayed -> sortedWith(compareBy { it.playCount })
             else -> this
         }
         return if (selectedDescending) years.reversed() else years
@@ -418,6 +436,7 @@ sealed class FileSortMode(
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
             KeySortItem.DateModified,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -431,6 +450,7 @@ sealed class FileSortMode(
             KeySortItem.DateAdded,
             KeySortItem.DateModified,
             KeySortItem.FileName,
+            KeySortItem.MostPlayed,
             DescendingItem
         )
     )
@@ -442,6 +462,7 @@ sealed class FileSortMode(
                 SortKey.SongCount -> folders.sortedWith(compareBy { it.songCount })
                 SortKey.DateAdded -> folders.sortedWith(compareBy { it.fileDateAdded })
                 SortKey.DateModified -> folders.sortedWith(compareBy { it.fileDateModified })
+                SortKey.MostPlayed -> folders.sortedWith(compareBy { it.playCount })
                 else -> folders
             }
         }.let { folders ->
@@ -457,6 +478,7 @@ sealed class FileSortMode(
                 SortKey.DateAdded -> songs.sortedWith(compareBy { it.fileDateAdded })
                 SortKey.DateModified -> songs.sortedWith(compareBy { it.fileDateModified })
                 SortKey.FileName -> songs.sortedWith(compareBy { it.fileName })
+                SortKey.MostPlayed -> songs.sortedWith(compareBy { it.playCount })
                 else -> songs
             }
         }.let { songs ->

--- a/app/src/main/java/com/mardous/booming/data/local/cache/PlayCountCache.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/cache/PlayCountCache.kt
@@ -1,0 +1,80 @@
+package com.mardous.booming.data.local.cache
+
+import com.mardous.booming.core.model.filesystem.FileSystemItem
+import com.mardous.booming.data.local.room.PlayCountDao
+import com.mardous.booming.data.local.room.PlayCountEntity
+import com.mardous.booming.data.model.Album
+import com.mardous.booming.data.model.Artist
+import com.mardous.booming.data.model.Folder
+import com.mardous.booming.data.model.Genre
+import com.mardous.booming.data.model.ReleaseYear
+import com.mardous.booming.data.model.Song
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class PlayCountCache(playCountDao: PlayCountDao) {
+
+    // Room emits asynchronously, so the cache can be empty during early startup.
+    // Koin creates this at app start to make that window unlikely before lists sort.
+    @Volatile
+    private var byId: Map<Long, Int> = emptyMap()
+
+    @Volatile
+    private var byGenreName: Map<String, Int> = emptyMap()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        playCountDao.allPlayCountsFlow()
+            .onEach { applyEntries(it) }
+            .launchIn(scope)
+    }
+
+    private fun applyEntries(entries: List<PlayCountEntity>) {
+        byId = entries.associate { it.id to it.playCount }
+        byGenreName = entries
+            .filter { !it.genreName.isNullOrEmpty() }
+            .groupBy { it.genreName!!.normalizeGenreKey() }
+            .mapValues { entry -> entry.value.sumOf { it.playCount } }
+    }
+
+    fun forSong(id: Long): Int = byId[id] ?: 0
+
+    fun forGenreName(name: String): Int = byGenreName[name.normalizeGenreKey()] ?: 0
+
+    private fun String.normalizeGenreKey(): String = trim().lowercase()
+}
+
+private object PlayCountCacheHolder : KoinComponent {
+    val cache: PlayCountCache by inject()
+}
+
+val Song.playCount: Int
+    get() = PlayCountCacheHolder.cache.forSong(id)
+
+val Album.playCount: Int
+    get() = songs.sumOf { it.playCount }
+
+val Artist.playCount: Int
+    get() = songs.sumOf { it.playCount }
+
+val Genre.playCount: Int
+    get() = PlayCountCacheHolder.cache.forGenreName(name)
+
+val ReleaseYear.playCount: Int
+    get() = songs.sumOf { it.playCount }
+
+val Folder.playCount: Int
+    get() = songs.sumOf { it.playCount }
+
+val FileSystemItem.playCount: Int
+    get() = when (this) {
+        is Song -> playCount
+        is Folder -> playCount
+        else -> 0
+    }

--- a/app/src/main/java/com/mardous/booming/data/local/cache/PlayCountCache.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/cache/PlayCountCache.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.util.Locale
 
 class PlayCountCache(playCountDao: PlayCountDao) {
 
@@ -47,7 +48,7 @@ class PlayCountCache(playCountDao: PlayCountDao) {
 
     fun forGenreName(name: String): Int = byGenreName[name.normalizeGenreKey()] ?: 0
 
-    private fun String.normalizeGenreKey(): String = trim().lowercase()
+    private fun String.normalizeGenreKey(): String = trim().lowercase(Locale.ROOT)
 }
 
 private object PlayCountCacheHolder : KoinComponent {

--- a/app/src/main/java/com/mardous/booming/data/local/room/PlayCountDao.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/room/PlayCountDao.kt
@@ -64,6 +64,9 @@ interface PlayCountDao {
         upsertSongInPlayCount(playCountEntity.copy(skipCount = playCountEntity.skipCount + 1))
     }
 
+    @Query("SELECT * FROM PlayCountEntity WHERE play_count > 0")
+    fun allPlayCountsFlow(): Flow<List<PlayCountEntity>>
+
     @Query("SELECT * FROM PlayCountEntity WHERE play_count > 0 ORDER BY play_count DESC LIMIT :limit")
     suspend fun playCountSongs(limit: Int = PLAY_COUNT_LIMIT): List<PlayCountEntity>
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -11,6 +11,7 @@
     <item name="action_sort_order_file_name" type="id"/>
     <item name="action_sort_order_number_of_albums" type="id"/>
     <item name="action_sort_order_number_of_songs" type="id"/>
+    <item name="action_sort_order_play_count" type="id"/>
     <item name="action_sort_order_descending" type="id"/>
     <item name="action_sort_order_ignore_articles" type="id"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
     <string name="sort_order_file_name">File name</string>
     <string name="sort_order_number_of_songs">Number of songs</string>
     <string name="sort_order_number_of_albums">Number of albums</string>
+    <string name="sort_order_play_count">Play count</string>
     <string name="sort_order_last_played_date">Last played date</string>
     <string name="sort_order_track_list">Track list</string>
     <string name="sort_order_descending">Descending</string>


### PR DESCRIPTION
Closes #184

Changes:
- Adds a play-count sort key and menu item.
- Supports play-count sorting across songs, albums, artists, genres, years, and folders.
- Adds a small Room-backed cache so list sorting can use play counts.

Note: live resorting after play-count updates is not included. We could handle such thing later if the library pipeline becomes reactive.

## Summary by Sourcery

Add play-count-based sorting across library views and back it with a Room-driven in-memory cache of play counts.

New Features:
- Introduce a MostPlayed sort key and menu entry for sorting by play count.
- Support play-count sorting for songs, albums, artists, genres, years, and folder-based file views.

Enhancements:
- Maintain a startup-initialized PlayCountCache fed by a Room flow to expose play counts across domain models via extension properties.