### PR TITLE
Add mini player swipe to skip preference

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/screen/other/MiniPlayerFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/other/MiniPlayerFragment.kt
@@ -101,7 +101,9 @@ class MiniPlayerFragment : Fragment(R.layout.fragment_mini_player),
         setupImageStyle()
         setUpButtons()
         setUpProgressStyle()
-        view.setOnTouchListener { _, event -> flingPlayBackController.onTouchEvent(event) }
+        view.setOnTouchListener { _, event ->
+            Preferences.miniPlayerSwipeToSkip && flingPlayBackController.onTouchEvent(event)
+        }
     }
 
     fun setupImageStyle() {

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -188,6 +188,9 @@ object Preferences : KoinComponent {
     val swipeOnCover: Boolean
         get() = preferences.getBoolean(SWIPE_ON_COVER, true)
 
+    val miniPlayerSwipeToSkip: Boolean
+        get() = preferences.getBoolean(MINI_PLAYER_SWIPE_TO_SKIP, true)
+
     var isQueueLocked: Boolean
         get() = preferences.getBoolean(LOCKED_QUEUE, false)
         set(value) = preferences.edit { putBoolean(LOCKED_QUEUE, value) }
@@ -564,6 +567,7 @@ const val SQUIGGLY_SEEK_BAR = "squiggly_seek_bar"
 const val SWIPE_DOWN_TO_DISMISS = "swipe_down_to_dismiss"
 const val LYRICS_ON_COVER = "lyrics_on_cover"
 const val SWIPE_ON_COVER = "swipe_on_cover"
+const val MINI_PLAYER_SWIPE_TO_SKIP = "mini_player_swipe_to_skip"
 const val NOW_PLAYING_SMALL_IMAGE = "now_playing_small_image"
 const val NOW_PLAYING_IMAGE_CORNER_RADIUS = "now_playing_corner_radius"
 const val PLAYER_BLUR_RADIUS = "player_blur_radius"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -739,6 +739,8 @@
     <string name="circle_button_title">Circular play button</string>
     <string name="swipe_album_cover_title">Swipe on album cover</string>
     <string name="swipe_album_cover_summary">Swipe left or right on the album cover to skip between songs.</string>
+    <string name="mini_player_swipe_to_skip_title">Swipe mini player to skip</string>
+    <string name="mini_player_swipe_to_skip_summary">Swipe left or right on the mini player to skip between songs.</string>
     <string name="queue_height_title">Half-screen queue height</string>
     <string name="queue_height_summary">Fix the playback queue height to half of the screen.</string>
     <string name="single_tap_on_album_cover_title">Single tap on cover</string>

--- a/app/src/main/res/xml/preferences_screen_now_playing.xml
+++ b/app/src/main/res/xml/preferences_screen_now_playing.xml
@@ -98,6 +98,15 @@
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="true"
+            app:title="@string/mini_player_swipe_to_skip_title"
+            app:summary="@string/mini_player_swipe_to_skip_summary"
+            app:defaultValue="true"
+            app:layout="@layout/list_item_view"
+            app:widgetLayout="@layout/preference_switch"
+            app:key="mini_player_swipe_to_skip" />
+
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="true"
             app:title="@string/swipe_up_queue_title"
             app:summary="@string/swipe_up_queue_summary"
             app:defaultValue="false"


### PR DESCRIPTION
Closes #403

## Summary by Sourcery

New Features:
- Introduce a toggle in the now playing settings to control swipe-to-skip behavior on the mini player.