### PR TITLE
Allow Pure Black to work together with Auto theme

### DIFF
--- a/app/src/main/java/com/mardous/booming/core/model/player/MetadataField.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/player/MetadataField.kt
@@ -49,6 +49,8 @@ class MetadataField(
         Composer(R.string.composer, MetadataReader.COMPOSER),
         Conductor(R.string.conductor, MetadataReader.PRODUCER),
         Publisher(R.string.publisher, MetadataReader.COPYRIGHT),
+        Lyricist(R.string.lyricist, MetadataReader.LYRICIST),
+        Arranger(R.string.arranger, MetadataReader.ARRANGER),
         Format(R.string.label_file_format, null),
         Bitrate(R.string.label_bit_rate, null),
         SampleRate(R.string.label_sampling_rate, null);

--- a/app/src/main/java/com/mardous/booming/core/model/theme/AppTheme.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/theme/AppTheme.kt
@@ -28,11 +28,14 @@ import com.mardous.booming.util.Preferences
 
 class AppTheme private constructor(
     val id: String,
-    @StyleRes
-    val themeRes: Int,
+    val mode: Mode,
     val applyDynamicColors: Boolean,
     val seedColor: Int? = null
 ) {
+
+    @StyleRes
+    val themeRes: Int
+        get() = mode.themeRes
 
     val isBlackTheme: Boolean
         get() = id == GeneralTheme.BLACK
@@ -49,20 +52,19 @@ class AppTheme private constructor(
             val generalTheme = Preferences.generalTheme
             // Auto+black: use FollowSystem so DayNight handles switching; BlackThemeOverlay
             // is applied separately (night-qualified) to get pure black only in dark mode.
-            val isAutoBlack = Preferences.blackTheme && Preferences.baseTheme == GeneralTheme.AUTO
-            val themeMode = if (isAutoBlack) AppTheme.Mode.FollowSystem else Preferences.getThemeMode(generalTheme)
+            val themeMode = if (Preferences.isAutoBlackTheme) Mode.FollowSystem else Preferences.getThemeMode(generalTheme)
             if (DynamicColors.isDynamicColorAvailable()) {
                 if (Preferences.isMaterialYouTheme) {
                     return AppTheme(
                         id = generalTheme,
-                        themeRes = themeMode.themeRes,
+                        mode = themeMode,
                         applyDynamicColors = true
                     )
                 }
                 if (context is ContextThemeWrapper) {
                     return AppTheme(
                         id = generalTheme,
-                        themeRes = themeMode.themeRes,
+                        mode = themeMode,
                         applyDynamicColors = true,
                         seedColor = ContextCompat.getColor(context, R.color.md_theme_primary)
                     )
@@ -70,7 +72,7 @@ class AppTheme private constructor(
             }
             return AppTheme(
                 id = generalTheme,
-                themeRes = themeMode.themeRes,
+                mode = themeMode,
                 applyDynamicColors = false
             )
         }

--- a/app/src/main/java/com/mardous/booming/core/model/theme/AppTheme.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/theme/AppTheme.kt
@@ -47,7 +47,10 @@ class AppTheme private constructor(
     companion object {
         fun createAppTheme(context: Context): AppTheme {
             val generalTheme = Preferences.generalTheme
-            val themeMode = Preferences.getThemeMode(generalTheme)
+            // Auto+black: use FollowSystem so DayNight handles switching; BlackThemeOverlay
+            // is applied separately (night-qualified) to get pure black only in dark mode.
+            val isAutoBlack = Preferences.blackTheme && Preferences.baseTheme == GeneralTheme.AUTO
+            val themeMode = if (isAutoBlack) AppTheme.Mode.FollowSystem else Preferences.getThemeMode(generalTheme)
             if (DynamicColors.isDynamicColorAvailable()) {
                 if (Preferences.isMaterialYouTheme) {
                     return AppTheme(

--- a/app/src/main/java/com/mardous/booming/data/local/MetadataReader.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/MetadataReader.kt
@@ -148,6 +148,7 @@ class MetadataReader(uri: Uri, readPictures: Boolean = false) : KoinComponent {
         const val YEAR = "DATE"
         const val LYRICS = "LYRICS"
         const val LYRICIST = "LYRICIST"
+        const val ARRANGER = "ARRANGER"
         const val COMPOSER = "COMPOSER"
         const val PRODUCER = "PRODUCER"
         const val COMMENT = "COMMENT"

--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsThemeActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsThemeActivity.kt
@@ -30,6 +30,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import com.google.android.material.color.DynamicColors
 import com.google.android.material.color.DynamicColorsOptions
 import com.mardous.booming.R
+import com.mardous.booming.core.model.theme.AppTheme
 import com.mardous.booming.extensions.createAppTheme
 import com.mardous.booming.extensions.hasQ
 import com.mardous.booming.extensions.resources.isColorLight
@@ -73,7 +74,7 @@ abstract class AbsThemeActivity : AppCompatActivity() {
                 dynamicColorsOptions.setContentBasedSource(appTheme.seedColor)
             }
             DynamicColors.applyToActivityIfAvailable(this, dynamicColorsOptions.build())
-        } else if (appTheme.isBlackTheme && appTheme.themeRes == R.style.Theme_Booming_FollowSystem) {
+        } else if (appTheme.isBlackTheme && appTheme.mode == AppTheme.Mode.FollowSystem) {
             // Auto+black without Material You: overlay applies black surfaces only in night mode
             // because BlackThemeOverlay is defined in values-night/ resource qualifiers.
             setTheme(R.style.BlackThemeOverlay)

--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsThemeActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsThemeActivity.kt
@@ -73,6 +73,10 @@ abstract class AbsThemeActivity : AppCompatActivity() {
                 dynamicColorsOptions.setContentBasedSource(appTheme.seedColor)
             }
             DynamicColors.applyToActivityIfAvailable(this, dynamicColorsOptions.build())
+        } else if (appTheme.isBlackTheme && appTheme.themeRes == R.style.Theme_Booming_FollowSystem) {
+            // Auto+black without Material You: overlay applies black surfaces only in night mode
+            // because BlackThemeOverlay is defined in values-night/ resource qualifiers.
+            setTheme(R.style.BlackThemeOverlay)
         }
         if (Preferences.isCustomFont) {
             setTheme(R.style.CustomFontThemeOverlay)

--- a/app/src/main/java/com/mardous/booming/ui/component/preferences/ThemePreference.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/preferences/ThemePreference.kt
@@ -24,7 +24,6 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.mardous.booming.R
-import com.mardous.booming.util.GeneralTheme
 import com.mardous.booming.util.Preferences
 
 /**
@@ -50,11 +49,9 @@ class ThemePreference @JvmOverloads constructor(
         // Disable ripple effect
         holder.itemView.background = null
 
-        val generalTheme = Preferences.generalTheme
         widgetView = holder.findViewById(android.R.id.widget_frame)
         widgetView?.findViewById<MaterialButtonToggleGroup>(R.id.buttonGroup)?.apply {
-            isEnabled = (generalTheme != GeneralTheme.BLACK)
-            check(generalTheme.let { selectorIds[it] ?: R.id.systemDefault })
+            check(Preferences.baseTheme.let { selectorIds[it] ?: R.id.systemDefault })
             addOnButtonCheckedListener(this@ThemePreference)
         }
     }

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/InfoResult.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/InfoResult.kt
@@ -37,6 +37,8 @@ data class SongInfo(
     val composer: String? = null,
     val conductor: String? = null,
     val publisher: String? = null,
+    val lyricist: String? = null,
+    val arranger: String? = null,
     val genre: String? = null,
     val replayGain: String? = null,
     val comment: String? = null
@@ -44,7 +46,7 @@ data class SongInfo(
     val isMissingMetadata: Boolean = album.isNullOrEmpty() && albumArtist.isNullOrEmpty() &&
             albumYear.isNullOrEmpty() && trackNumber.isNullOrEmpty() && discNumber.isNullOrEmpty() &&
             composer.isNullOrEmpty() && conductor.isNullOrEmpty() && publisher.isNullOrEmpty() &&
-            genre.isNullOrEmpty()
+            lyricist.isNullOrEmpty() && arranger.isNullOrEmpty() && genre.isNullOrEmpty()
 
     companion object {
         val Empty = SongInfo()

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/InfoViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/InfoViewModel.kt
@@ -121,6 +121,8 @@ class InfoViewModel(private val repository: Repository) : ViewModel() {
                 val composer = metadataReader.merge(MetadataReader.COMPOSER)
                 val conductor = metadataReader.merge(MetadataReader.PRODUCER)
                 val publisher = metadataReader.merge(MetadataReader.COPYRIGHT)
+                val lyricist = metadataReader.merge(MetadataReader.LYRICIST)
+                val arranger = metadataReader.merge(MetadataReader.ARRANGER)
                 val genre = metadataReader.merge(MetadataReader.GENRE)
                 val comment = metadataReader.value(MetadataReader.COMMENT)
 
@@ -143,6 +145,8 @@ class InfoViewModel(private val repository: Repository) : ViewModel() {
                     composer = composer,
                     conductor = conductor,
                     publisher = publisher,
+                    lyricist = lyricist,
+                    arranger = arranger,
                     genre = genre,
                     replayGain = replayGain,
                     comment = comment

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/SongDetailFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/SongDetailFragment.kt
@@ -307,6 +307,16 @@ class SongDetailFragment : BottomSheetDialogFragment() {
                 title = stringResource(R.string.publisher),
                 content = songInfo.publisher
             )
+
+            InfoView(
+                title = stringResource(R.string.lyricist),
+                content = songInfo.lyricist
+            )
+
+            InfoView(
+                title = stringResource(R.string.arranger),
+                content = songInfo.arranger
+            )
         }
     }
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/tageditor/SongTagEditorActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/tageditor/SongTagEditorActivity.kt
@@ -71,6 +71,7 @@ class SongTagEditorActivity : AbsTagEditorActivity() {
             songBinding.discTotal.setText(tagResult.discTotal)
             songBinding.lyrics.setText(tagResult.lyrics)
             songBinding.lyricist.setText(tagResult.lyricist)
+            songBinding.arranger.setText(tagResult.arranger)
             songBinding.comment.setText(tagResult.comment)
         }
         viewModel.loadContent()
@@ -140,6 +141,7 @@ class SongTagEditorActivity : AbsTagEditorActivity() {
             MetadataReader.DISC_TOTAL to songBinding.discTotal.text?.toString(),
             MetadataReader.LYRICS to songBinding.lyrics.text?.toString(),
             MetadataReader.LYRICIST to songBinding.lyricist.text?.toString(),
+            MetadataReader.ARRANGER to songBinding.arranger.text?.toString(),
             MetadataReader.COMMENT to songBinding.comment.text?.toString()
         )
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorResult.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorResult.kt
@@ -33,6 +33,7 @@ data class TagEditorResult(
     val discTotal: String? = null,
     val lyrics: String? = null,
     val lyricist: String? = null,
+    val arranger: String? = null,
     val comment: String? = null
 )
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorViewModel.kt
@@ -94,6 +94,7 @@ class TagEditorViewModel(
                     discTotal = metadataReader.value(MetadataReader.DISC_TOTAL),
                     lyrics = metadataReader.value(MetadataReader.LYRICS),
                     lyricist = metadataReader.merge(MetadataReader.LYRICIST),
+                    arranger = metadataReader.merge(MetadataReader.ARRANGER),
                     comment = metadataReader.value(MetadataReader.COMMENT)
                 )
                 _tagResult.postValue(newValue)

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -91,7 +91,7 @@ object Preferences : KoinComponent {
         GeneralTheme.BLACK -> {
             // When black mode is active but the base theme is Auto, follow the system so that
             // light mode shows the light theme and dark mode shows pure black.
-            if (baseTheme == GeneralTheme.AUTO) {
+            if (isAutoBlackTheme) {
                 if (hasQ()) AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM else AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
             } else {
                 AppCompatDelegate.MODE_NIGHT_YES
@@ -109,6 +109,10 @@ object Preferences : KoinComponent {
 
     val baseTheme: String
         get() = preferences.requireString(GENERAL_THEME, GeneralTheme.AUTO)
+
+    /** True when Auto + Pure Black are active together, requiring FollowSystem night mode. */
+    val isAutoBlackTheme: Boolean
+        get() = blackTheme && baseTheme == GeneralTheme.AUTO
 
     val isMaterialYouTheme: Boolean
         get() = preferences.getBoolean(MATERIAL_YOU, hasS())

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -87,8 +87,16 @@ object Preferences : KoinComponent {
 
     fun getDayNightMode(themeName: String = generalTheme) = when (themeName) {
         GeneralTheme.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-        GeneralTheme.DARK,
-        GeneralTheme.BLACK -> AppCompatDelegate.MODE_NIGHT_YES
+        GeneralTheme.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+        GeneralTheme.BLACK -> {
+            // When black mode is active but the base theme is Auto, follow the system so that
+            // light mode shows the light theme and dark mode shows pure black.
+            if (baseTheme == GeneralTheme.AUTO) {
+                if (hasQ()) AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM else AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+            } else {
+                AppCompatDelegate.MODE_NIGHT_YES
+            }
+        }
         else -> if (hasQ()) {
             AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
         } else {
@@ -98,6 +106,9 @@ object Preferences : KoinComponent {
 
     val blackTheme: Boolean
         get() = preferences.getBoolean(BLACK_THEME, false)
+
+    val baseTheme: String
+        get() = preferences.requireString(GENERAL_THEME, GeneralTheme.AUTO)
 
     val isMaterialYouTheme: Boolean
         get() = preferences.getBoolean(MATERIAL_YOU, hasS())

--- a/app/src/main/res/layout/tag_editor_song_field.xml
+++ b/app/src/main/res/layout/tag_editor_song_field.xml
@@ -292,12 +292,30 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/arranger_text_input_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/arranger"
+        app:layout_constraintTop_toBottomOf="@+id/lyricist_text_input_layout">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/arranger"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:inputType="text|textCapWords"
+            tools:ignore="Autofill"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/comment_text_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:hint="@string/comment"
-        app:layout_constraintTop_toBottomOf="@+id/lyricist_text_input_layout">
+        app:layout_constraintTop_toBottomOf="@+id/arranger_text_input_layout">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/comment"

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BlackThemeOverlay">
+        <item name="colorSurface">@android:color/black</item>
+        <item name="colorSurfaceContainer">@color/surfaceContainerBlack</item>
+        <item name="colorSurfaceContainerLow">@color/surfaceContainerLowBlack</item>
+        <item name="colorSurfaceContainerLowest">@color/surfaceContainerLowestBlack</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,6 +316,7 @@
     <string name="disc_total">Total Discs</string>
     <string name="lyrics">Lyrics</string>
     <string name="lyricist">Lyricist</string>
+    <string name="arranger">Arranger</string>
     <string name="could_not_load_the_song_information">"Couldn't load the song information."</string>
     <string name="no_results">No results</string>
     <string name="connection_unavailable">Connection unavailable.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,9 @@
 
     <style name="Theme.Booming.FollowSystem" parent="Base.Theme.Booming.Adaptive"/>
 
+    <!-- No-op in light mode; values-night/ provides the black surface override -->
+    <style name="BlackThemeOverlay"/>
+
     <style name="Theme.Booming.SplashScreen" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowBackground">@drawable/splash</item>
         <item name="android:statusBarColor">@android:color/transparent</item>


### PR DESCRIPTION
## Related Issue

Closes #406

## Summary

- The theme toggle (Light / Dark / Auto) is now enabled even when Pure Black is turned on
- Selecting Auto + Pure Black now follows the system: light mode shows regular light theme, dark mode shows pure black AMOLED theme
- Selecting Dark + Pure Black continues to behave exactly as before (always-dark pure black)

## How it works

| Setting | Before | After |
|---|---|---|
| Pure Black OFF, Auto | Follow system | Follow system (no change) |
| Pure Black ON, Auto | Always dark + pure black (toggle disabled) | Follow system; pure black only in dark mode |
| Pure Black ON, Dark | Always dark + pure black | Always dark + pure black (no change) |

## Key changes

1. **Preferences.kt** - Added baseTheme (raw stored preference, independent of blackTheme). Updated getDayNightMode so BLACK + Auto base uses MODE_NIGHT_FOLLOW_SYSTEM instead of always MODE_NIGHT_YES.

2. **AppTheme.kt** - createAppTheme now selects Mode.FollowSystem for the Auto+black combination so the DayNight theme resource handles light/dark switching.

3. **AbsThemeActivity.kt** - Applies BlackThemeOverlay in the non-Material-You Auto+black path. Because BlackThemeOverlay is defined in values-night/ qualifiers, pure black colors are only active in dark mode.

4. **ThemePreference.kt** - Removed the isEnabled guard so the toggle is always usable. The checked button now reflects baseTheme (the stored value) rather than the effective theme.

5. **values-night/styles.xml** (new) - Adds BlackThemeOverlay for pre-API 31 devices.

## Test plan

- [ ] Enable Pure Black, theme toggle should remain interactive
- [ ] Select Auto + Pure Black, system light mode shows light theme; switch system to dark mode and app shows pure black AMOLED theme
- [ ] Select Dark + Pure Black, app always shows dark pure black (existing behavior unchanged)
- [ ] Disable Pure Black while Auto is selected, app follows system normally
- [ ] Material You + Auto + Pure Black works correctly

## Summary by Sourcery

Enable the Pure Black option to work with the Auto theme so that the app follows the system setting while using a pure black AMOLED variant only in dark mode.

New Features:
- Allow selecting Auto theme together with Pure Black so the app follows the system while using pure black only in dark mode.

Enhancements:
- Keep the theme toggle (Light / Dark / Auto) interactive regardless of Pure Black being enabled, with the selection reflecting the stored base theme.
- Adjust theme resolution logic so Black + Auto follows the system instead of forcing always-dark mode.
- Apply a night-only black theme overlay in non–Material You flows and add a corresponding values-night style to ensure pure black surfaces only in dark mode.