### PR TITLE
Add Arranger and Lyricist tag field support

### DIFF
--- a/app/src/main/java/com/mardous/booming/core/model/player/MetadataField.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/player/MetadataField.kt
@@ -49,6 +49,8 @@ class MetadataField(
         Composer(R.string.composer, MetadataReader.COMPOSER),
         Conductor(R.string.conductor, MetadataReader.PRODUCER),
         Publisher(R.string.publisher, MetadataReader.COPYRIGHT),
+        Lyricist(R.string.lyricist, MetadataReader.LYRICIST),
+        Arranger(R.string.arranger, MetadataReader.ARRANGER),
         Format(R.string.label_file_format, null),
         Bitrate(R.string.label_bit_rate, null),
         SampleRate(R.string.label_sampling_rate, null);

--- a/app/src/main/java/com/mardous/booming/data/local/MetadataReader.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/MetadataReader.kt
@@ -148,6 +148,7 @@ class MetadataReader(uri: Uri, readPictures: Boolean = false) : KoinComponent {
         const val YEAR = "DATE"
         const val LYRICS = "LYRICS"
         const val LYRICIST = "LYRICIST"
+        const val ARRANGER = "ARRANGER"
         const val COMPOSER = "COMPOSER"
         const val PRODUCER = "PRODUCER"
         const val COMMENT = "COMMENT"

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/InfoResult.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/InfoResult.kt
@@ -43,6 +43,9 @@ data class SongInfo(
     val replayGain: String? = null,
     val comment: String? = null
 ) {
+    // True only when every optional metadata field is absent; gates the metadata section in the UI.
+    // lyricist and arranger are included alongside composer/conductor/publisher for consistency:
+    // the section should appear whenever any credit or descriptive tag has content.
     val isMissingMetadata: Boolean = album.isNullOrEmpty() && albumArtist.isNullOrEmpty() &&
             albumYear.isNullOrEmpty() && trackNumber.isNullOrEmpty() && discNumber.isNullOrEmpty() &&
             composer.isNullOrEmpty() && conductor.isNullOrEmpty() && publisher.isNullOrEmpty() &&

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/InfoResult.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/InfoResult.kt
@@ -37,6 +37,8 @@ data class SongInfo(
     val composer: String? = null,
     val conductor: String? = null,
     val publisher: String? = null,
+    val lyricist: String? = null,
+    val arranger: String? = null,
     val genre: String? = null,
     val replayGain: String? = null,
     val comment: String? = null
@@ -44,7 +46,7 @@ data class SongInfo(
     val isMissingMetadata: Boolean = album.isNullOrEmpty() && albumArtist.isNullOrEmpty() &&
             albumYear.isNullOrEmpty() && trackNumber.isNullOrEmpty() && discNumber.isNullOrEmpty() &&
             composer.isNullOrEmpty() && conductor.isNullOrEmpty() && publisher.isNullOrEmpty() &&
-            genre.isNullOrEmpty()
+            lyricist.isNullOrEmpty() && arranger.isNullOrEmpty() && genre.isNullOrEmpty()
 
     companion object {
         val Empty = SongInfo()

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/InfoViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/InfoViewModel.kt
@@ -121,6 +121,8 @@ class InfoViewModel(private val repository: Repository) : ViewModel() {
                 val composer = metadataReader.merge(MetadataReader.COMPOSER)
                 val conductor = metadataReader.merge(MetadataReader.PRODUCER)
                 val publisher = metadataReader.merge(MetadataReader.COPYRIGHT)
+                val lyricist = metadataReader.merge(MetadataReader.LYRICIST)
+                val arranger = metadataReader.merge(MetadataReader.ARRANGER)
                 val genre = metadataReader.merge(MetadataReader.GENRE)
                 val comment = metadataReader.value(MetadataReader.COMMENT)
 
@@ -143,6 +145,8 @@ class InfoViewModel(private val repository: Repository) : ViewModel() {
                     composer = composer,
                     conductor = conductor,
                     publisher = publisher,
+                    lyricist = lyricist,
+                    arranger = arranger,
                     genre = genre,
                     replayGain = replayGain,
                     comment = comment

--- a/app/src/main/java/com/mardous/booming/ui/screen/info/SongDetailFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/info/SongDetailFragment.kt
@@ -307,6 +307,16 @@ class SongDetailFragment : BottomSheetDialogFragment() {
                 title = stringResource(R.string.publisher),
                 content = songInfo.publisher
             )
+
+            InfoView(
+                title = stringResource(R.string.lyricist),
+                content = songInfo.lyricist
+            )
+
+            InfoView(
+                title = stringResource(R.string.arranger),
+                content = songInfo.arranger
+            )
         }
     }
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/tageditor/SongTagEditorActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/tageditor/SongTagEditorActivity.kt
@@ -71,6 +71,7 @@ class SongTagEditorActivity : AbsTagEditorActivity() {
             songBinding.discTotal.setText(tagResult.discTotal)
             songBinding.lyrics.setText(tagResult.lyrics)
             songBinding.lyricist.setText(tagResult.lyricist)
+            songBinding.arranger.setText(tagResult.arranger)
             songBinding.comment.setText(tagResult.comment)
         }
         viewModel.loadContent()
@@ -140,6 +141,7 @@ class SongTagEditorActivity : AbsTagEditorActivity() {
             MetadataReader.DISC_TOTAL to songBinding.discTotal.text?.toString(),
             MetadataReader.LYRICS to songBinding.lyrics.text?.toString(),
             MetadataReader.LYRICIST to songBinding.lyricist.text?.toString(),
+            MetadataReader.ARRANGER to songBinding.arranger.text?.toString(),
             MetadataReader.COMMENT to songBinding.comment.text?.toString()
         )
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorResult.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorResult.kt
@@ -33,6 +33,7 @@ data class TagEditorResult(
     val discTotal: String? = null,
     val lyrics: String? = null,
     val lyricist: String? = null,
+    val arranger: String? = null,
     val comment: String? = null
 )
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/tageditor/TagEditorViewModel.kt
@@ -94,6 +94,7 @@ class TagEditorViewModel(
                     discTotal = metadataReader.value(MetadataReader.DISC_TOTAL),
                     lyrics = metadataReader.value(MetadataReader.LYRICS),
                     lyricist = metadataReader.merge(MetadataReader.LYRICIST),
+                    arranger = metadataReader.merge(MetadataReader.ARRANGER),
                     comment = metadataReader.value(MetadataReader.COMMENT)
                 )
                 _tagResult.postValue(newValue)

--- a/app/src/main/res/layout/tag_editor_song_field.xml
+++ b/app/src/main/res/layout/tag_editor_song_field.xml
@@ -292,12 +292,30 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/arranger_text_input_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/arranger"
+        app:layout_constraintTop_toBottomOf="@+id/lyricist_text_input_layout">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/arranger"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:inputType="text|textCapWords"
+            tools:ignore="Autofill"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/comment_text_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:hint="@string/comment"
-        app:layout_constraintTop_toBottomOf="@+id/lyricist_text_input_layout">
+        app:layout_constraintTop_toBottomOf="@+id/arranger_text_input_layout">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/comment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,6 +316,7 @@
     <string name="disc_total">Total Discs</string>
     <string name="lyrics">Lyrics</string>
     <string name="lyricist">Lyricist</string>
+    <string name="arranger">Arranger</string>
     <string name="could_not_load_the_song_information">"Couldn't load the song information."</string>
     <string name="no_results">No results</string>
     <string name="connection_unavailable">Connection unavailable.</string>


### PR DESCRIPTION
## Related Issue

Closes #422

## Summary

Adds full read/write/display support for the **Arranger** and **Lyricist** tag fields — both standard Vorbis/FLAC fields already supported by the underlying taglib library.

Lyricist was already partially implemented (layout field, string, and TagEditorResult entry existed) but was missing from the song detail info sheet and the Now Playing metadata field picker. This PR completes it and adds Arranger in exactly the same way.

## Changes

| File | Change |
|---|---|
| MetadataReader.kt | Added ARRANGER constant |
| TagEditorResult.kt | Added arranger field |
| TagEditorViewModel.kt | Read arranger when loading tags |
| SongTagEditorActivity.kt | Bind arranger UI field; include in propertyMap written to file |
| tag_editor_song_field.xml | Add arranger input between lyricist and comment |
| strings.xml | Add Arranger display string |
| InfoResult.kt | Add lyricist and arranger to SongInfo; include in isMissingMetadata |
| InfoViewModel.kt | Read lyricist and arranger into SongInfo |
| SongDetailFragment.kt | Display lyricist and arranger in the metadata section |
| MetadataField.kt | Add Lyricist and Arranger to Content enum for Now Playing picker |

## Test plan

- [ ] Open tag editor for a track, verify Lyricist and Arranger input fields appear
- [ ] Enter values for Lyricist and Arranger, save, reopen tag editor and verify values are persisted
- [ ] Open song detail sheet, verify Lyricist and Arranger appear in the Metadata section when set
- [ ] Open Now Playing info field picker, verify Lyricist and Arranger appear as selectable options

## Summary by Sourcery

Add full support for Lyricist and Arranger audio tags across metadata reading, editing, and display.

New Features:
- Expose Arranger as a new editable metadata field in the song tag editor and underlying tag result model.
- Include Lyricist and Arranger in the song detail metadata view and Now Playing metadata field picker.
- Extend metadata reading to load Lyricist and Arranger tags into the song info model.

Enhancements:
- Treat Lyricist and Arranger as contributing fields when determining if a track is missing metadata.