### PR TITLE
Normalize Chinese spacing

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -116,7 +116,7 @@
     <string name="song_x_of_x">%1$d / %2$d • %3$s</string>
     <string name="no_equalizer">未找到均衡器。</string>
     <string name="audio_focus_denied">音频焦点被拒绝。</string>
-    <string name="no_audio_ID">错误的音频ID。</string>
+    <string name="no_audio_ID">错误的音频 ID。</string>
     <string name="playback_error_code">播放错误 （%s）。</string>
     <string name="unplayable_file">无法播放这首歌曲。</string>
     <string name="permission_external_storage_title">存储访问</string>
@@ -126,7 +126,7 @@
     <string name="permission_bluetooth_description">此应用需要附近的设备权限来检查蓝牙设备</string>
     <string name="permission_bluetooth_denied">附近设备权限被拒绝。</string>
     <string name="permission_read_images_title">查看图片（可选）</string>
-    <string name="permission_read_images_summary">为了帮您自动查找并显示歌曲的专辑封面，Booming Music需要获取访问您音乐文件夹的权限。 您可以根据需要决定是否授予此权限。</string>
+    <string name="permission_read_images_summary">为了帮您自动查找并显示歌曲的专辑封面，Booming Music 需要获取访问您音乐文件夹的权限。 您可以根据需要决定是否授予此权限。</string>
     <string name="permission_read_images_denied">您需要授予访问所有文件的权限以允许软件读取封面图片。</string>
     <string name="permission_exact_alarms_title">设置精确闹钟(可选)</string>
     <string name="permission_exact_alarms_description">睡眠计时器需要获取设置精确闹钟的权限才能正常工作</string>
@@ -235,7 +235,7 @@
     <string name="new_start_directory">新建起始目录: %s</string>
     <string name="action_scan">扫描</string>
     <string name="scan_media">扫描媒体</string>
-    <string name="scan_media_message">Android系统通常会自动检测并索引您设备上的媒体文件，所以一般情况下您不需要手动扫描媒体。</string>
+    <string name="scan_media_message">Android 系统通常会自动检测并索引您设备上的媒体文件，所以一般情况下您不需要手动扫描媒体。</string>
     <string name="scan_media_positive">仍进行扫描</string>
     <string name="scan_finished">扫描已完成。</string>
     <string name="album_or_artist_empty">标题或艺术家是空的。</string>
@@ -406,9 +406,9 @@
     <string name="not_supported">不支持</string>
     <string name="set_eq_engine_title">设置均衡引擎</string>
     <string name="eq_engine_basic_title">传统引擎</string>
-    <string name="eq_engine_basic_description">5频段经典配置，设备兼容性更好。</string>
+    <string name="eq_engine_basic_description">5 频段经典配置，设备兼容性更好。</string>
     <string name="eq_engine_precision_title">精密引擎</string>
-    <string name="eq_engine_precision_description">高保真处理引擎，最高支持15频段调节，声效塑造效果更好。</string>
+    <string name="eq_engine_precision_description">高保真处理引擎，最高支持 15 频段调节，声效塑造效果更好。</string>
     <string name="set_eq_engine_reset_warning">更改均衡引擎将重置均衡器设置，包括自定义配置。</string>
     <string name="eq_empty_bands">均衡引擎未返回任何频段配置。</string>
     <string name="enable_equalizer">启用均衡器</string>
@@ -456,7 +456,7 @@
     <string name="synced_lyrics">同步歌词</string>
     <string name="embedded_lyrics">内嵌歌词</string>
     <string name="downloaded_lyrics">已下载</string>
-    <string name="cannot_download_lyrics">Booming Music无法找到这首歌的歌词。您想手动搜索吗？</string>
+    <string name="cannot_download_lyrics">Booming Music 无法找到这首歌的歌词。您想手动搜索吗？</string>
     <string name="search_lyrics">搜索歌词</string>
     <string name="choose_lyrics">选择歌词类型</string>
     <string name="download_lyrics">下载歌词</string>
@@ -473,9 +473,9 @@
     <string name="sleep_timer_cancel_current_timer">取消</string>
     <string name="sleep_timer_set_action">设置</string>
     <string name="sleep_timer_x_mins">%d分钟</string>
-    <string name="sleep_timer_15_mins">15分钟</string>
-    <string name="sleep_timer_45_mins">45分钟</string>
-    <string name="sleep_timer_1_hour">1小时</string>
+    <string name="sleep_timer_15_mins">15 分钟</string>
+    <string name="sleep_timer_45_mins">45 分钟</string>
+    <string name="sleep_timer_1_hour">1 小时</string>
     <string name="sleep_timer_2_hour">2 小时</string>
     <string name="sleep_timer_finish_current_music">播放完最后一首</string>
     <string name="sleep_timer_music_fades_out">逐渐减弱音乐音量</string>
@@ -497,25 +497,25 @@
     <string name="contributors">贡献者</string>
     <string name="acknowledgments_title">致谢</string>
     <string name="translators_title">译者</string>
-    <string name="translators_summary">感谢那些为Booming Music提供多种语言的人们。</string>
+    <string name="translators_summary">感谢那些为 Booming Music 提供多种语言的人们。</string>
     <string name="contributors_title">贡献者</string>
     <string name="contributors_summary">以各种方式参与贡献该项目的用户清单。</string>
     <string name="view_profile_on_github">在 GitHub 上查看个人资料</string>
     <string name="write_an_email">电子邮件</string>
     <string name="support_development">支持开发</string>
     <string name="help_with_translations">帮助翻译</string>
-    <string name="help_with_translations_summary">您可以通过帮助将Booming Music翻译成其他语言来为该项目做出贡献。</string>
+    <string name="help_with_translations_summary">您可以通过帮助将 Booming Music 翻译成其他语言来为该项目做出贡献。</string>
     <string name="report_bugs">报告错误</string>
     <string name="report_bugs_summary">报告错误或请求新功能。</string>
     <string name="share_app">分享此应用</string>
     <string name="share_app_summary">您可以与朋友分享本应用，帮助它成长壮大。</string>
     <string name="send_invitation_message">发送邀请信息</string>
-    <string name="invitation_message_content">你好，来看看Booming Music吧！这是Android平台最好的本地音乐播放器。下载链接： %s</string>
+    <string name="invitation_message_content">你好，来看看 Booming Music 吧！这是 Android 平台最好的本地音乐播放器。下载链接： %s</string>
     <!-- Bug report -->
     <string name="you_will_be_forwarded_to_the_issue_tracker_website">即将跳转到问题跟踪网站。</string>
     <!-- SAF -->
     <string name="saf_access_required_title">需要存储访问</string>
-    <string name="saf_access_required_message">Booming Music需要访问这些文件的权限。请选择您存储音乐文件的根文件夹。</string>
+    <string name="saf_access_required_message">Booming Music 需要访问这些文件的权限。请选择您存储音乐文件的根文件夹。</string>
     <string name="saf_show_files_button">显示文件</string>
     <string name="saf_error_uri">无法获取 SAF URI</string>
     <string name="saf_write_failed">文件写入失败： %s</string>
@@ -602,7 +602,7 @@
     <string name="instrumental_tracks_mark_by_title_summary">识别纯音乐时一并在曲目标题中查找纯音乐判断词。</string>
     <string name="ignore_blank_lines_title">忽略空行</string>
     <string name="ignore_blank_lines_summary">忽略 LRC 文件中的空行，而不将其显示为气泡动画。</string>
-    <string name="treat_all_lyrics_files_as_utf8_title">将所有歌词文件视为UTF-8</string>
+    <string name="treat_all_lyrics_files_as_utf8_title">将所有歌词文件视为 UTF-8</string>
     <string name="treat_all_lyrics_files_as_utf8_summary">强制以 UTF-8 编码读取音频文件。 这优化了文件解析过程，但在某些情况下可能导致歌曲歌词中出现异常字符。 可能需要重启应用</string>
     <!-- Now playing preferences -->
     <string name="now_playing_screen_title">样式</string>
@@ -676,8 +676,8 @@
     <string name="ignore_audio_focus_summary">无视正在播放的任何其他音频，始终保持音频后台播放。</string>
     <string name="pause_on_zero_volume_title">在静音时停止播放</string>
     <string name="pause_on_zero_volume_summary">当音量下降为零时暂停歌曲，并在音量上升时恢复播放。同时支持在应用程序外工作。</string>
-    <string name="mp3_index_seeking_title">MP3索引定位</string>
-    <string name="mp3_index_seeking_summary">将整个MP3文件加载到内存中，以便跳转而不是依赖Xing 头部信息。 只在跳转部分VBR文件失败时使用。 需要重启应用程序。</string>
+    <string name="mp3_index_seeking_title">MP3 索引定位</string>
+    <string name="mp3_index_seeking_summary">将整个 MP3 文件加载到内存中，以便跳转而不是依赖 Xing 头部信息。 只在跳转部分 VBR 文件失败时使用。 需要重启应用程序。</string>
     <string name="play_option_always_visible_title">始终显示“播放”选项</string>
     <string name="play_option_always_visible_summary">如果启用该选项，无论点击行为设置为何，“播放”按钮将一直出现在歌曲菜单中。</string>
     <string name="play_option_whole_list_title">“播放”选项播放整个列表</string>
@@ -699,7 +699,7 @@
     <string name="clear_queue_on_completion_title">播放完毕时清空队列</string>
     <string name="clear_queue_on_completion_summary">在最后一曲播完后，自动从播放队列中移除所有曲目。</string>
     <!-- Metadata preferences -->
-    <string name="ignore_media_store_album_covers_title">忽略MediaStore提供的封面</string>
+    <string name="ignore_media_store_album_covers_title">忽略 MediaStore 提供的封面</string>
     <string name="ignore_media_store_album_covers_summary">这可能有助于提高图像质量，但需要更多内存。</string>
     <string name="use_folder_album_cover_title">使用文件夹图像</string>
     <string name="use_folder_album_cover_summary">如果音频文件不包含嵌入封面。图像可能需要一些时间才能加载。</string>
@@ -754,7 +754,7 @@
     <string name="gradient_style">渐变</string>
     <string name="peek_style">灵动</string>
     <string name="plain_style">简洁</string>
-    <string name="m3_style">M3风格</string>
+    <string name="m3_style">M3 风格</string>
     <string name="expressive_style">丰富</string>
     <string name="normal_style">默认</string>
     <string name="cascading">卡片翻转</string>
@@ -798,7 +798,7 @@
     <string name="player_color_mode_vibrant_color_title">鲜艳色彩</string>
     <string name="player_color_mode_vibrant_color_description">将专辑颜色应用于提示背景、文本和控件</string>
     <string name="player_color_mode_material_you_title">Material You</string>
-    <string name="player_color_mode_material_you_description">启用基于专辑封面颜色的Material You配色</string>
+    <string name="player_color_mode_material_you_description">启用基于专辑封面颜色的 Material You 配色</string>
     <string name="player_color_mode_blur_title">模糊</string>
     <string name="player_color_mode_blur_description">使用 Material You 色彩模糊背景</string>
     <!-- Update -->
@@ -824,7 +824,7 @@
     <string name="uncaught_error_report">错误报告</string>
     <string name="uncaught_error_report_copied">已复制错误报告到剪贴板。</string>
     <string name="uncaught_error_restart_app">重启应用</string>
-    <string name="uncaught_error_github">在GitHub上反馈问题</string>
+    <string name="uncaught_error_github">在 GitHub 上反馈问题</string>
     <string name="uncaught_error_send">发送报告</string>
     <string name="support_my_work">支持我的作品</string>
     <string name="lastfm_login_username">用户名</string>
@@ -872,7 +872,7 @@
     <string name="channel_surround_13_1">13.1 声道环绕声</string>
     <string name="lyrics_center_horizontally_title">歌词横向居中</string>
     <string name="lyrics_center_horizontally_summary">将每行歌词对齐到屏幕的水平线中心。</string>
-    <string name="bit_perfect_info">Bit Perfect信息：%1$s|%2$s</string>
+    <string name="bit_perfect_info">Bit Perfect 信息：%1$s|%2$s</string>
     <string name="bit_perfect_title">Bit-perfect 音频</string>
     <string name="app_widget_responsive">响应式</string>
     <string name="app_widget_responsive_desc">根据大小自动适配小部件布局</string>
@@ -909,8 +909,8 @@
     <string name="login_action">登录</string>
     <string name="logout_action">退出登录</string>
     <string name="sign_in_to_x_title">登录到%s</string>
-    <string name="error_listenbrainz_generic">ListenBrainz发生了错误。</string>
-    <string name="error_listenbrainz_invalid_token">无效的ListenBrainz凭据。</string>
+    <string name="error_listenbrainz_generic">ListenBrainz 发生了错误。</string>
+    <string name="error_listenbrainz_invalid_token">无效的 ListenBrainz 凭据。</string>
     <string name="listenbrainz_token_label">用户凭据</string>
     <string name="listenbrainz_title">ListenBrainz</string>
     <string name="listenbrainz_login_title">登录 ListenBrainz</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -116,7 +116,7 @@
     <string name="song_x_of_x">%1$d / %2$d • %3$s</string>
     <string name="no_equalizer">未找到均衡器。</string>
     <string name="audio_focus_denied">音訊焦點被拒絕。</string>
-    <string name="no_audio_ID">錯誤的音訊ID。</string>
+    <string name="no_audio_ID">錯誤的音訊 ID。</string>
     <string name="playback_error_code">音樂面板錯誤 (%s)。</string>
     <string name="unplayable_file">無法播放這首歌曲。</string>
     <string name="permission_external_storage_title">存儲訪問</string>
@@ -126,7 +126,7 @@
     <string name="permission_bluetooth_description">此應用需要附近的設備權限來檢查藍牙設備</string>
     <string name="permission_bluetooth_denied">附近設備權限被拒絕。</string>
     <string name="permission_read_images_title">查看圖片（可選）</string>
-    <string name="permission_read_images_summary">為了幫您自動查找並顯示歌曲的專輯封面，Booming Music需要獲取訪問您音樂資料夾的權限。 您可以根據需要決定是否授予此權限。</string>
+    <string name="permission_read_images_summary">為了幫您自動查找並顯示歌曲的專輯封面，Booming Music 需要獲取訪問您音樂資料夾的權限。 您可以根據需要決定是否授予此權限。</string>
     <string name="permission_read_images_denied">您需要授予訪問所有檔案的權限以允許軟體讀取封面圖片。</string>
     <string name="permission_exact_alarms_title">設定精確鬧鐘(可選)</string>
     <string name="permission_exact_alarms_description">睡眠計時器需獲取設定精確鬧鐘的權限才能正常工作</string>
@@ -235,7 +235,7 @@
     <string name="new_start_directory">新建起始目錄: %s</string>
     <string name="action_scan">掃描</string>
     <string name="scan_media">掃描媒體</string>
-    <string name="scan_media_message">Android系統通常會自動檢測並索引您設備上的媒體檔案，所以一般情況下您不需要手動掃描媒體。</string>
+    <string name="scan_media_message">Android 系統通常會自動檢測並索引您設備上的媒體檔案，所以一般情況下您不需要手動掃描媒體。</string>
     <string name="scan_media_positive">仍進行掃描</string>
     <string name="scan_finished">掃描已完成。</string>
     <string name="album_or_artist_empty">標題或藝術家是空的。</string>
@@ -411,7 +411,7 @@
     <string name="eq_engine_precision_description">High-fidelity processing with up to 15-band control for ultimate acoustic shaping.</string>
     <string name="set_eq_engine_reset_warning">Changing the equalization engine will reset the equalizer settings, including custom profiles.</string>
     <string name="eq_empty_bands">The equalization engine did not return any band configurations.</string>
-    <string name="enable_equalizer">啟用EQ</string>
+    <string name="enable_equalizer">啟用 EQ</string>
     <string name="select_profile">Select profile</string>
     <string name="save_profile_label">Save profile</string>
     <string name="edit_profile_label">Edit profile</string>
@@ -440,7 +440,7 @@
     <string name="unlock_pitch_adjustment">Unlock pitch adjustment</string>
     <string name="balance_left">左</string>
     <string name="balance_right">Right</string>
-    <string name="action_external_eq">外部EQ</string>
+    <string name="action_external_eq">外部 EQ</string>
     <string name="custom">自訂</string>
     <string name="audio_offload_is_enabled">Audio Offload is Enabled</string>
     <string name="enable_audio_offload_title">音訊硬體加速</string>
@@ -456,7 +456,7 @@
     <string name="synced_lyrics">同步歌詞</string>
     <string name="embedded_lyrics">內嵌歌詞</string>
     <string name="downloaded_lyrics">已下載</string>
-    <string name="cannot_download_lyrics">Booming Music無法找到這首歌的歌詞。您想手動搜尋嗎？</string>
+    <string name="cannot_download_lyrics">Booming Music 無法找到這首歌的歌詞。您想手動搜尋嗎？</string>
     <string name="search_lyrics">搜尋歌詞</string>
     <string name="choose_lyrics">選擇歌詞類型</string>
     <string name="download_lyrics">下載歌詞</string>
@@ -497,25 +497,25 @@
     <string name="contributors">貢獻者</string>
     <string name="acknowledgments_title">致謝</string>
     <string name="translators_title">譯者</string>
-    <string name="translators_summary">感謝那些為Booming Music提供多種語言的人們。</string>
+    <string name="translators_summary">感謝那些為 Booming Music 提供多種語言的人們。</string>
     <string name="contributors_title">貢獻者</string>
     <string name="contributors_summary">A list of users who have contributed to the project in some way.</string>
     <string name="view_profile_on_github">在 GitHub 上查看個人資料</string>
     <string name="write_an_email">電子郵件</string>
     <string name="support_development">支援開發</string>
     <string name="help_with_translations">幫助翻譯</string>
-    <string name="help_with_translations_summary">您可以通過幫助將Booming Music翻譯成其他語言來為該項目做出貢獻。</string>
+    <string name="help_with_translations_summary">您可以通過幫助將 Booming Music 翻譯成其他語言來為該項目做出貢獻。</string>
     <string name="report_bugs">報告錯誤</string>
     <string name="report_bugs_summary">報告錯誤或請求新功能。</string>
     <string name="share_app">分享此應用</string>
     <string name="share_app_summary">如果你與朋友分享，你可以幫助這個應用的發展。</string>
     <string name="send_invitation_message">發送邀請訊息</string>
-    <string name="invitation_message_content">您好。看看Booming Music！在Android上聆聽本地音樂的最佳應用程式。您可以從這裡下載它： %s</string>
+    <string name="invitation_message_content">您好。看看 Booming Music！在 Android 上聆聽本地音樂的最佳應用程式。您可以從這裡下載它： %s</string>
     <!-- Bug report -->
     <string name="you_will_be_forwarded_to_the_issue_tracker_website">即將跳轉到問題跟蹤網站。</string>
     <!-- SAF -->
     <string name="saf_access_required_title">需要存儲訪問</string>
-    <string name="saf_access_required_message">Booming Music需要訪問這些檔案的權限。請選擇您存儲音樂檔案的根資料夾。</string>
+    <string name="saf_access_required_message">Booming Music 需要訪問這些檔案的權限。請選擇您存儲音樂檔案的根資料夾。</string>
     <string name="saf_show_files_button">顯示檔案</string>
     <string name="saf_error_uri">無法獲取 SAF URI</string>
     <string name="saf_write_failed">檔案寫入失敗： %s</string>
@@ -602,7 +602,7 @@
     <string name="instrumental_tracks_mark_by_title_summary">在搜尋識別資料時，還將考慮曲目標題。</string>
     <string name="ignore_blank_lines_title">忽略空白行</string>
     <string name="ignore_blank_lines_summary">Ignore empty lines in LRC files instead of showing animated bubbles.</string>
-    <string name="treat_all_lyrics_files_as_utf8_title">將所有歌詞檔案視為UTF-8</string>
+    <string name="treat_all_lyrics_files_as_utf8_title">將所有歌詞檔案視為 UTF-8</string>
     <string name="treat_all_lyrics_files_as_utf8_summary">Assume that all files use UTF-8 encoding. This optimizes the file parsing process but in some cases could result in unusual characters in song lyrics. It might require an app restart</string>
     <!-- Now playing preferences -->
     <string name="now_playing_screen_title">樣式</string>
@@ -676,8 +676,8 @@
     <string name="ignore_audio_focus_summary">總是在後臺播放音訊，不管是否播放任何其他音訊。</string>
     <string name="pause_on_zero_volume_title">在靜音時停止播放</string>
     <string name="pause_on_zero_volume_summary">當音量下降為零時暫停歌曲，並在音量上升時恢復播放。同時支援在應用程式外工作。</string>
-    <string name="mp3_index_seeking_title">MP3索引定位</string>
-    <string name="mp3_index_seeking_summary">將整個MP3檔案載入到記憶體中，以便跳轉而不是依賴Xing 頭部訊息。 只在跳轉部分VBR檔案失敗時使用。 需要重啟應用程式。</string>
+    <string name="mp3_index_seeking_title">MP3 索引定位</string>
+    <string name="mp3_index_seeking_summary">將整個 MP3 檔案載入到記憶體中，以便跳轉而不是依賴 Xing 頭部訊息。 只在跳轉部分 VBR 檔案失敗時使用。 需要重啟應用程式。</string>
     <string name="play_option_always_visible_title">Keep \"Play\" option visible</string>
     <string name="play_option_always_visible_summary">If enabled, the \"Play\" option will always appear in a song\'s menu, regardless of tap behavior settings.</string>
     <string name="play_option_whole_list_title">\"Play\" option plays whole list</string>
@@ -699,7 +699,7 @@
     <string name="clear_queue_on_completion_title">Clear queue when playback finishes</string>
     <string name="clear_queue_on_completion_summary">Automatically remove all songs from the queue after the last track finishes playing.</string>
     <!-- Metadata preferences -->
-    <string name="ignore_media_store_album_covers_title">忽略MediaStore提供的封面</string>
+    <string name="ignore_media_store_album_covers_title">忽略 MediaStore 提供的封面</string>
     <string name="ignore_media_store_album_covers_summary">這可能有助於提高圖片品質，但需要更多記憶體。</string>
     <string name="use_folder_album_cover_title">使用資料夾圖像</string>
     <string name="use_folder_album_cover_summary">如果音訊檔案不包含嵌入封面。圖像可能需要一些時間才能載入。</string>
@@ -754,7 +754,7 @@
     <string name="gradient_style">漸層</string>
     <string name="peek_style">Peek</string>
     <string name="plain_style">樸素</string>
-    <string name="m3_style">M3風格</string>
+    <string name="m3_style">M3 風格</string>
     <string name="expressive_style">Expressive</string>
     <string name="normal_style">普通</string>
     <string name="cascading">卡片翻轉</string>
@@ -798,7 +798,7 @@
     <string name="player_color_mode_vibrant_color_title">亮色</string>
     <string name="player_color_mode_vibrant_color_description">將專輯顏色應用於提示背景、文字和模組</string>
     <string name="player_color_mode_material_you_title">Material You</string>
-    <string name="player_color_mode_material_you_description">啟用基於專輯封面顏色的Material You配色</string>
+    <string name="player_color_mode_material_you_description">啟用基於專輯封面顏色的 Material You 配色</string>
     <string name="player_color_mode_blur_title">模糊</string>
     <string name="player_color_mode_blur_description">Blurred background with Material You colors</string>
     <!-- Update -->
@@ -824,7 +824,7 @@
     <string name="uncaught_error_report">錯誤報告</string>
     <string name="uncaught_error_report_copied">已複製錯誤報告到剪貼簿。</string>
     <string name="uncaught_error_restart_app">重啟應用</string>
-    <string name="uncaught_error_github">在GitHub上回饋問題</string>
+    <string name="uncaught_error_github">在 GitHub 上回饋問題</string>
     <string name="uncaught_error_send">發送報告</string>
     <string name="app_widget_responsive">響應式</string>
     <string name="app_widget_responsive_desc">一個能夠根據不同尺寸調整版面的小工具</string>


### PR DESCRIPTION
This PR normalizes spacing between Chinese text and embedded English words / Arabic numerals in zh-rCN and zh-rTW strings.
No translation meaning was changed. I rebuilt the normalDebug APK and verified the app runs correctly.
I noticed translations are managed on Weblate. Since this formatting adjustment affects spacing across dozens of translated strings, and adjusting them one by one on Weblate would be rather tedious, I am attempting to submit a PR here instead. If you prefer translation-only changes to go through Weblate, I’m happy to re-submit them there.

## Summary by Sourcery

Enhancements:
- Improve readability and consistency of zh-rCN and zh-rTW UI strings by adding appropriate spaces around English words, product names, acronyms, and numerals.