### PR TITLE
Natural sorting

### DIFF
--- a/app/src/main/java/com/mardous/booming/core/model/sort/SortItem.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/sort/SortItem.kt
@@ -7,10 +7,10 @@ sealed class SortItem(val group: Int, val id: Int, val title: Int)
 sealed class KeySortItem(id: Int, title: Int, val key: SortKey)
     : SortItem(group = 0, id = id, title = title) {
 
-    object Title : KeySortItem(
-        R.id.action_sort_order_az,
-        R.string.sort_order_az,
-        SortKey.AZ
+    object Name : KeySortItem(
+        R.id.action_sort_order_name,
+        R.string.sort_order_name,
+        SortKey.Name
     )
 
     object Album : KeySortItem(

--- a/app/src/main/java/com/mardous/booming/core/model/sort/SortKey.kt
+++ b/app/src/main/java/com/mardous/booming/core/model/sort/SortKey.kt
@@ -1,7 +1,7 @@
 package com.mardous.booming.core.model.sort
 
 enum class SortKey(val value: String) {
-    AZ("az_key"),
+    Name("az_key"), // keep user preference, we can clean this up at some point, but im not gonna be making that call :D
     Album("album_key"),
     Artist("artist_key"),
     Duration("duration_key"),

--- a/app/src/main/java/com/mardous/booming/core/sort/SortCollator.kt
+++ b/app/src/main/java/com/mardous/booming/core/sort/SortCollator.kt
@@ -5,11 +5,17 @@ import android.icu.text.RuleBasedCollator
 import com.mardous.booming.extensions.media.normalizeForSorting
 import com.mardous.booming.util.Preferences
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
-fun sortingCollator(): Collator =
-    Collator.getInstance(Locale.getDefault()).apply {
-        strength = Collator.PRIMARY
-        (this as? RuleBasedCollator)?.numericCollation = true
+private val collators = ConcurrentHashMap<Locale, Collator>()
+
+// Frozen
+fun sortingCollator(locale: Locale = Locale.getDefault()): Collator =
+    collators.computeIfAbsent(locale) {
+        Collator.getInstance(it).apply {
+            strength = Collator.PRIMARY
+            (this as? RuleBasedCollator)?.numericCollation = true
+        }.freeze()
     }
 
 fun <T> Iterable<T>.sortedByName(selector: (T) -> String): List<T> =

--- a/app/src/main/java/com/mardous/booming/core/sort/SortCollator.kt
+++ b/app/src/main/java/com/mardous/booming/core/sort/SortCollator.kt
@@ -1,0 +1,22 @@
+package com.mardous.booming.core.sort
+
+import android.icu.text.Collator
+import android.icu.text.RuleBasedCollator
+import com.mardous.booming.extensions.media.normalizeForSorting
+import com.mardous.booming.util.Preferences
+import java.util.Locale
+
+fun sortingCollator(): Collator =
+    Collator.getInstance(Locale.getDefault()).apply {
+        strength = Collator.PRIMARY
+        (this as? RuleBasedCollator)?.numericCollation = true
+    }
+
+fun <T> Iterable<T>.sortedByName(selector: (T) -> String): List<T> =
+    sortedWith(compareBy(sortingCollator()) { selector(it) })
+
+fun <T> Iterable<T>.sortedByMediaName(selector: (T) -> String): List<T> {
+    val ignoreArticles = Preferences.ignoreArticlesWhenSorting
+    val language = Locale.getDefault().language
+    return sortedByName { selector(it).normalizeForSorting(ignoreArticles, language) }
+}

--- a/app/src/main/java/com/mardous/booming/core/sort/SortMode.kt
+++ b/app/src/main/java/com/mardous/booming/core/sort/SortMode.kt
@@ -1,6 +1,7 @@
 package com.mardous.booming.core.sort
 
 import android.content.SharedPreferences
+import android.icu.text.Collator
 import android.view.Menu
 import android.view.MenuItem
 import androidx.core.content.edit
@@ -15,9 +16,9 @@ import com.mardous.booming.data.model.*
 import com.mardous.booming.extensions.media.albumArtistName
 import com.mardous.booming.extensions.media.asReadableTrackNumber
 import com.mardous.booming.extensions.media.normalizeForSorting
+import com.mardous.booming.util.Preferences
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
-import java.text.Collator
 import java.util.Locale
 
 sealed class SortMode(
@@ -26,12 +27,10 @@ sealed class SortMode(
     private val items: List<SortItem>
 ) : KoinComponent {
 
-    protected val collator: Collator by lazy {
-        Collator.getInstance(Locale.getDefault()).apply { strength = Collator.PRIMARY }
-    }
+    protected val collator: Collator by lazy { sortingCollator() }
 
     val ignoreArticles: Boolean
-        get() =  get<SharedPreferences>().getBoolean("ignore_articles_when_sorting", false)
+        get() = Preferences.ignoreArticlesWhenSorting
 
     private val key = "${id}_sort_order"
     open var selectedKey: SortKey
@@ -111,6 +110,11 @@ sealed class SortMode(
     }
 }
 
+private fun <T, K : Comparable<K>> List<T>.sortedWithTiebreak(
+    tiebreak: Comparator<T>,
+    selector: (T) -> K
+): List<T> = sortedWith(compareBy(selector).then(tiebreak))
+
 sealed class SongSortMode(
     id: String,
     defaults: Pair<SortKey, Boolean>,
@@ -119,9 +123,9 @@ sealed class SongSortMode(
 
     object AllSongs : SongSortMode(
         id = "song",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Artist,
             KeySortItem.Album,
             KeySortItem.Duration,
@@ -137,7 +141,7 @@ sealed class SongSortMode(
         id = "album_song",
         defaults = SortKey.Track to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Track,
             KeySortItem.Duration,
             DescendingItem
@@ -146,9 +150,9 @@ sealed class SongSortMode(
 
     object ArtistSongs : SongSortMode(
         id = "artist_song",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Album,
             KeySortItem.Duration,
             KeySortItem.Year,
@@ -159,9 +163,9 @@ sealed class SongSortMode(
 
     object GenreSongs : SongSortMode(
         id = "genre_song",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Artist,
             KeySortItem.Album,
             KeySortItem.Duration,
@@ -171,9 +175,9 @@ sealed class SongSortMode(
 
     object YearSongs : SongSortMode(
         id = "year_song",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Artist,
             KeySortItem.Album,
             KeySortItem.Duration,
@@ -185,7 +189,7 @@ sealed class SongSortMode(
         id = "folder_song",
         defaults = SortKey.DateAdded to true,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Artist,
             KeySortItem.Album,
             KeySortItem.Duration,
@@ -203,28 +207,25 @@ sealed class SongSortMode(
     ) : SongSortMode("dynamic_song", selectedKey to selectedDescending, items)
 
     fun List<Song>.sorted(): List<Song> {
+        val byTitle: Comparator<Song> = compareBy(collator) { it.title.normalize() }
         val songs = when (selectedKey) {
-            SortKey.AZ -> sortedWith(compareBy(collator) {
-                it.title.normalize()
-            })
+            SortKey.Name -> sortedWith(byTitle)
 
-            SortKey.Artist -> sortedWith(compareBy(collator) {
-                it.artistName.normalize()
-            })
-
-            SortKey.Album -> sortedWith(
-                Comparator.comparing<Song, String>({ it.albumName.normalize() }, collator)
-                    .thenComparingInt {
-                        if (it.trackNumber > 0) it.trackNumber else Int.MAX_VALUE
-                    }
+            SortKey.Artist -> sortedWith(
+                compareBy<Song, String>(collator) { it.artistName.normalize() }.then(byTitle)
             )
 
-            SortKey.Track -> sortedWith(compareBy { it.trackNumber })
-            SortKey.Duration -> sortedWith(compareBy { it.duration })
-            SortKey.Year -> sortedWith(compareBy { it.year })
-            SortKey.DateAdded -> sortedWith(compareBy { it.dateAdded })
-            SortKey.DateModified -> sortedWith(compareBy { it.rawDateModified })
-            SortKey.FileName -> sortedWith(compareBy { it.fileName })
+            SortKey.Album -> sortedWith(
+                compareBy<Song, String>(collator) { it.albumName.normalize() }
+                    .thenBy { if (it.trackNumber > 0) it.trackNumber else Int.MAX_VALUE }
+            )
+
+            SortKey.Track -> sortedWithTiebreak(byTitle) { it.trackNumber }
+            SortKey.Duration -> sortedWithTiebreak(byTitle) { it.duration }
+            SortKey.Year -> sortedWithTiebreak(byTitle) { it.year }
+            SortKey.DateAdded -> sortedWithTiebreak(byTitle) { it.dateAdded }
+            SortKey.DateModified -> sortedWithTiebreak(byTitle) { it.rawDateModified }
+            SortKey.FileName -> sortedWith(compareBy(collator) { it.fileName })
             else -> this
         }
         return if (selectedDescending) songs.reversed() else songs
@@ -239,9 +240,9 @@ sealed class AlbumSortMode(
 
     object AllAlbums : AlbumSortMode(
         id = "album",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Artist,
             KeySortItem.Year,
             KeySortItem.SongCount,
@@ -254,7 +255,7 @@ sealed class AlbumSortMode(
         id = "artist_album",
         defaults = SortKey.Year to true,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Year,
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
@@ -264,9 +265,9 @@ sealed class AlbumSortMode(
 
     object SimilarAlbums : AlbumSortMode(
         id = "similar_album",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Year,
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
@@ -275,18 +276,17 @@ sealed class AlbumSortMode(
     )
 
     fun List<Album>.sorted(): List<Album> {
+        val byName: Comparator<Album> = compareBy(collator) { it.name.normalize() }
         val albums = when (selectedKey) {
-            SortKey.AZ -> sortedWith(compareBy(collator) {
-                it.name.normalize()
-            })
+            SortKey.Name -> sortedWith(byName)
 
-            SortKey.Artist -> sortedWith(compareBy(collator) {
-                it.albumArtistName().normalize()
-            })
+            SortKey.Artist -> sortedWith(
+                compareBy<Album, String>(collator) { it.albumArtistName().normalize() }.then(byName)
+            )
 
-            SortKey.Year -> sortedWith(compareBy { it.year })
-            SortKey.SongCount -> sortedWith(compareBy { it.songCount })
-            SortKey.DateAdded -> sortedWith(compareBy { it.dateAdded })
+            SortKey.Year -> sortedWithTiebreak(byName) { it.year }
+            SortKey.SongCount -> sortedWithTiebreak(byName) { it.songCount }
+            SortKey.DateAdded -> sortedWithTiebreak(byName) { it.dateAdded }
             else -> this
         }
         return if (selectedDescending) albums.reversed() else albums
@@ -301,9 +301,9 @@ sealed class ArtistSortMode(
 
     object AllArtists : ArtistSortMode(
         id = "artist",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.SongCount,
             KeySortItem.AlbumCount,
             DescendingItem
@@ -311,12 +311,11 @@ sealed class ArtistSortMode(
     )
 
     fun List<Artist>.sorted(): List<Artist> {
+        val byName: Comparator<Artist> = compareBy(collator) { it.name.normalize() }
         val artists = when (selectedKey) {
-            SortKey.AZ -> sortedWith(compareBy(collator) {
-                it.name.normalize()
-            })
-            SortKey.SongCount -> sortedWith(compareBy({ it.songCount }, { it.name.normalize() }))
-            SortKey.AlbumCount -> sortedWith(compareBy({ it.albumCount }, { it.name.normalize() }))
+            SortKey.Name -> sortedWith(byName)
+            SortKey.SongCount -> sortedWithTiebreak(byName) { it.songCount }
+            SortKey.AlbumCount -> sortedWithTiebreak(byName) { it.albumCount }
             else -> this
         }
         return if (selectedDescending) artists.reversed() else artists
@@ -331,21 +330,19 @@ sealed class GenreSortMode(
 
     object AllGenres : GenreSortMode(
         id = "genre",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.SongCount,
             DescendingItem
         )
     )
 
     fun List<Genre>.sorted(): List<Genre> {
+        val byName: Comparator<Genre> = compareBy(collator) { it.name.normalize() }
         val genres = when (selectedKey) {
-            SortKey.AZ -> sortedWith(compareBy(collator) {
-                it.name.normalize()
-            })
-
-            SortKey.SongCount -> sortedWith(compareBy { it.songCount })
+            SortKey.Name -> sortedWith(byName)
+            SortKey.SongCount -> sortedWithTiebreak(byName) { it.songCount }
             else -> this
         }
         return if (selectedDescending) genres.reversed() else genres
@@ -371,7 +368,7 @@ sealed class YearSortMode(
     fun List<ReleaseYear>.sorted(): List<ReleaseYear> {
         val years = when (selectedKey) {
             SortKey.Year -> sortedWith(compareBy { it.year })
-            SortKey.SongCount -> sortedWith(compareBy { it.songCount })
+            SortKey.SongCount -> sortedWithTiebreak(compareBy { it.year }) { it.songCount }
             else -> this
         }
         return if (selectedDescending) years.reversed() else years
@@ -386,18 +383,21 @@ sealed class PlaylistSortMode(
 
     object AllPlaylists : PlaylistSortMode(
         id = "playlist",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.SongCount,
             DescendingItem
         )
     )
 
     fun List<PlaylistWithSongs>.sorted(): List<PlaylistWithSongs> {
+        val byName: Comparator<PlaylistWithSongs> = compareBy(collator) {
+            it.playlistEntity.playlistName.normalize()
+        }
         val playlists = when (selectedKey) {
-            SortKey.AZ -> sortedWith(compareBy { it.playlistEntity.playlistName })
-            SortKey.SongCount -> sortedWith(compareBy { it.songCount })
+            SortKey.Name -> sortedWith(byName)
+            SortKey.SongCount -> sortedWithTiebreak(byName) { it.songCount }
             else -> this
         }
         return if (selectedDescending) playlists.reversed() else playlists
@@ -412,9 +412,9 @@ sealed class FileSortMode(
 
     object AllFolders : FileSortMode(
         id = "folder",
-        defaults = SortKey.AZ to false,
+        defaults = SortKey.Name to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.SongCount,
             KeySortItem.DateAdded,
             KeySortItem.DateModified,
@@ -426,7 +426,7 @@ sealed class FileSortMode(
         id = "file",
         defaults = SortKey.FileName to false,
         items = listOf(
-            KeySortItem.Title,
+            KeySortItem.Name,
             KeySortItem.Track,
             KeySortItem.DateAdded,
             KeySortItem.DateModified,
@@ -436,12 +436,15 @@ sealed class FileSortMode(
     )
 
     fun List<FileSystemItem>.sorted(): List<FileSystemItem> {
+        val byFolderName: Comparator<Folder> = compareBy(collator) { it.fileName }
+        val byTitle: Comparator<Song> = compareBy(collator) { it.title.normalize() }
+
         val sortedFolders = filterIsInstance<Folder>().let { folders ->
             when (selectedKey) {
-                SortKey.AZ -> folders.sortedWith(compareBy { it.fileName })
-                SortKey.SongCount -> folders.sortedWith(compareBy { it.songCount })
-                SortKey.DateAdded -> folders.sortedWith(compareBy { it.fileDateAdded })
-                SortKey.DateModified -> folders.sortedWith(compareBy { it.fileDateModified })
+                SortKey.Name -> folders.sortedWith(byFolderName)
+                SortKey.SongCount -> folders.sortedWithTiebreak(byFolderName) { it.songCount }
+                SortKey.DateAdded -> folders.sortedWithTiebreak(byFolderName) { it.fileDateAdded }
+                SortKey.DateModified -> folders.sortedWithTiebreak(byFolderName) { it.fileDateModified }
                 else -> folders
             }
         }.let { folders ->
@@ -450,13 +453,13 @@ sealed class FileSortMode(
 
         val sortedSongs = filterIsInstance<Song>().let { songs ->
             when (selectedKey) {
-                SortKey.AZ -> songs.sortedWith(compareBy { it.title })
-                SortKey.Track -> songs.sortedWith(compareBy {
+                SortKey.Name -> songs.sortedWith(byTitle)
+                SortKey.Track -> songs.sortedWithTiebreak(byTitle) {
                     if (it.trackNumber > 0) it.trackNumber.asReadableTrackNumber() else -1
-                })
-                SortKey.DateAdded -> songs.sortedWith(compareBy { it.fileDateAdded })
-                SortKey.DateModified -> songs.sortedWith(compareBy { it.fileDateModified })
-                SortKey.FileName -> songs.sortedWith(compareBy { it.fileName })
+                }
+                SortKey.DateAdded -> songs.sortedWithTiebreak(byTitle) { it.fileDateAdded }
+                SortKey.DateModified -> songs.sortedWithTiebreak(byTitle) { it.fileDateModified }
+                SortKey.FileName -> songs.sortedWith(compareBy(collator) { it.fileName })
                 else -> songs
             }
         }.let { songs ->

--- a/app/src/main/java/com/mardous/booming/core/sort/SortMode.kt
+++ b/app/src/main/java/com/mardous/booming/core/sort/SortMode.kt
@@ -27,7 +27,8 @@ sealed class SortMode(
     private val items: List<SortItem>
 ) : KoinComponent {
 
-    protected val collator: Collator by lazy { sortingCollator() }
+    protected val collator: Collator
+        get() = sortingCollator()
 
     val ignoreArticles: Boolean
         get() = Preferences.ignoreArticlesWhenSorting

--- a/app/src/main/java/com/mardous/booming/data/local/repository/SpecialRepository.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/repository/SpecialRepository.kt
@@ -18,9 +18,11 @@
 package com.mardous.booming.data.local.repository
 
 import android.provider.MediaStore.Audio.AudioColumns
+import com.mardous.booming.core.model.filesystem.FileSystemItem
 import com.mardous.booming.core.model.filesystem.FileSystemQuery
 import com.mardous.booming.core.sort.SongSortMode
 import com.mardous.booming.core.sort.YearSortMode
+import com.mardous.booming.core.sort.sortingCollator
 import com.mardous.booming.data.model.Folder
 import com.mardous.booming.data.model.ReleaseYear
 import com.mardous.booming.data.model.Song
@@ -38,6 +40,8 @@ interface SpecialRepository {
 }
 
 class RealSpecialRepository(private val songRepository: RealSongRepository) : SpecialRepository {
+
+    private val collator by lazy { sortingCollator() }
 
     override suspend fun releaseYears(): List<ReleaseYear> {
         val songs = songRepository.songs(
@@ -93,15 +97,17 @@ class RealSpecialRepository(private val songRepository: RealSongRepository) : Sp
     }
 
     override suspend fun songsByFolder(path: String, includeSubfolders: Boolean): List<Song> {
-        if (includeSubfolders) {
+        val songs = if (includeSubfolders) {
             val dirPath = path.takeIf { it.endsWith("/") } ?: "$path/"
             val cursor = songRepository.makeSongCursor(
                 selection = "${AudioColumns.DATA} LIKE ?",
                 selectionValues = arrayOf("$dirPath%")
             )
-            return songRepository.songs(cursor)
+            songRepository.songs(cursor)
+        } else {
+            songRepository.songs().filter { song -> path == song.folderPath() }
         }
-        return songRepository.songs().filter { song -> path == song.folderPath() }
+        return with(SongSortMode.FolderSongs) { songs.sorted() }
     }
 
     override suspend fun songsByFolder(path: String, query: String): List<Song> {
@@ -159,7 +165,9 @@ class RealSpecialRepository(private val songRepository: RealSongRepository) : Sp
         val children = buildList {
             addAll(subfolders)
             addAll(songsInThisFolder)
-        }.sortedWith(compareBy({ it is Song }, { it.fileName.lowercase() }))
+        }.sortedWith(
+            compareBy<FileSystemItem> { it is Song }.thenBy(collator) { it.fileName }
+        )
 
         return FileSystemQuery(name, path, parentPath, children)
     }

--- a/app/src/main/java/com/mardous/booming/data/local/repository/SpecialRepository.kt
+++ b/app/src/main/java/com/mardous/booming/data/local/repository/SpecialRepository.kt
@@ -41,8 +41,6 @@ interface SpecialRepository {
 
 class RealSpecialRepository(private val songRepository: RealSongRepository) : SpecialRepository {
 
-    private val collator by lazy { sortingCollator() }
-
     override suspend fun releaseYears(): List<ReleaseYear> {
         val songs = songRepository.songs(
             songRepository.makeSongCursor("${AudioColumns.YEAR} > 0", null)
@@ -166,7 +164,7 @@ class RealSpecialRepository(private val songRepository: RealSongRepository) : Sp
             addAll(subfolders)
             addAll(songsInThisFolder)
         }.sortedWith(
-            compareBy<FileSystemItem> { it is Song }.thenBy(collator) { it.fileName }
+            compareBy<FileSystemItem> { it is Song }.thenBy(sortingCollator()) { it.fileName }
         )
 
         return FileSystemQuery(name, path, parentPath, children)

--- a/app/src/main/java/com/mardous/booming/extensions/media/MediaExt.kt
+++ b/app/src/main/java/com/mardous/booming/extensions/media/MediaExt.kt
@@ -111,8 +111,7 @@ fun String.normalizeForSorting(
     language: String = Locale.getDefault().language
 ): String {
     return if (ignoreArticles) {
-        val articles = ARTICLES_BY_LANGUAGE[language] ?: return this
-        val regex = Regex("^(${articles.joinToString("|")})\\s+", RegexOption.IGNORE_CASE)
+        val regex = ARTICLES_REGEX_BY_LANGUAGE[language] ?: return this
         return trim().replace(regex, "")
     } else {
         this
@@ -128,3 +127,7 @@ private val ARTICLES_BY_LANGUAGE = mapOf(
     "pt" to listOf("o", "a", "os", "as", "um", "uma"),
     "nl" to listOf("de", "het", "een")
 )
+
+private val ARTICLES_REGEX_BY_LANGUAGE = ARTICLES_BY_LANGUAGE.mapValues { (_, articles) ->
+    Regex("^(${articles.joinToString("|")})\\s+", RegexOption.IGNORE_CASE)
+}

--- a/app/src/main/java/com/mardous/booming/ui/adapters/album/AlbumAdapter.kt
+++ b/app/src/main/java/com/mardous/booming/ui/adapters/album/AlbumAdapter.kt
@@ -122,7 +122,7 @@ open class AlbumAdapter(
         val album = dataSet.getOrNull(position) ?: return ""
         return when (sortMode?.selectedKey) {
             SortKey.Artist -> album.displayArtistName().asSectionName(sortMode)
-            SortKey.AZ -> album.name.asSectionName(sortMode)
+            SortKey.Name -> album.name.asSectionName(sortMode)
             else -> album.name.asSectionName(sortMode)
         }
     }

--- a/app/src/main/java/com/mardous/booming/ui/adapters/song/SongAdapter.kt
+++ b/app/src/main/java/com/mardous/booming/ui/adapters/song/SongAdapter.kt
@@ -140,7 +140,7 @@ open class SongAdapter(
         return when (sortMode?.selectedKey) {
             SortKey.Album -> song.albumName.asSectionName(sortMode)
             SortKey.Artist -> song.displayArtistName().asSectionName(sortMode)
-            SortKey.AZ -> song.title.asSectionName(sortMode)
+            SortKey.Name -> song.title.asSectionName(sortMode)
             SortKey.Year -> ""
             SortKey.FileName -> song.fileName.asSectionName(sortMode)
             else -> song.title.asSectionName(sortMode)

--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsTagEditorActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsTagEditorActivity.kt
@@ -26,6 +26,7 @@ import coil3.request.crossfade
 import coil3.target.Target
 import coil3.toBitmap
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.mardous.booming.core.sort.sortedByName
 import com.mardous.booming.data.local.EditTarget
 import com.mardous.booming.databinding.ActivityTagEditorBinding
 import com.mardous.booming.extensions.*
@@ -215,7 +216,7 @@ abstract class AbsTagEditorActivity : AbsBaseActivity(),
 
     private val defaultGenreSelector: Dialog by lazy {
         val titles = GenreTypes.getInstanceOf()
-            .idToValueMap.values.sorted().toTypedArray()
+            .idToValueMap.values.sortedByName { it }.toTypedArray()
 
         MaterialAlertDialogBuilder(this)
             .setItems(titles) { _: DialogInterface, i: Int -> onDefaultGenreSelection(titles[i]) }

--- a/app/src/main/java/com/mardous/booming/ui/dialogs/library/FolderChooserDialog.kt
+++ b/app/src/main/java/com/mardous/booming/ui/dialogs/library/FolderChooserDialog.kt
@@ -31,6 +31,7 @@ import androidx.core.app.ActivityCompat.checkSelfPermission
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.mardous.booming.R
+import com.mardous.booming.core.sort.sortedByName
 import com.mardous.booming.databinding.DialogRecyclerViewBinding
 import com.mardous.booming.extensions.create
 import com.mardous.booming.extensions.hasT
@@ -159,7 +160,7 @@ class FolderChooserDialog : DialogFragment(), SimpleItemAdapter.Callback<String>
         val results = mutableListOf<File>()
         parentFolder?.listFiles()?.let { files ->
             files.forEach { file -> if (file.isDirectory) results.add(file) }
-            return results.sortedBy { it.name }.toTypedArray()
+            return results.sortedByName { it.name }.toTypedArray()
         }
         return null
     }

--- a/app/src/main/java/com/mardous/booming/ui/screen/library/artists/ArtistDetailViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/library/artists/ArtistDetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
+import com.mardous.booming.core.sort.sortedByMediaName
 import com.mardous.booming.data.local.repository.Repository
 import com.mardous.booming.data.model.Artist
 import com.mardous.booming.data.model.network.NetworkFeature
@@ -37,7 +38,7 @@ class ArtistDetailViewModel(
     }
 
     fun getSimilarArtists(artist: Artist): LiveData<List<Artist>> = liveData(Dispatchers.IO) {
-        emit(repository.similarAlbumArtists(artist).sortedBy { it.name })
+        emit(repository.similarAlbumArtists(artist).sortedByMediaName { it.name })
     }
 
     fun getArtistBio(

--- a/app/src/main/java/com/mardous/booming/ui/screen/library/artists/ArtistListFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/library/artists/ArtistListFragment.kt
@@ -63,7 +63,7 @@ class ArtistListFragment : AbsRecyclerViewCustomGridSizeFragment<ArtistAdapter, 
             playerViewModel.openShuffle(
                 providers = it,
                 mode = Preferences.artistShuffleMode,
-                sortMode = SongSortMode.Dynamic(SortKey.AZ)
+                sortMode = SongSortMode.Dynamic(SortKey.Name)
             ).observe(viewLifecycleOwner) { success ->
                 if (success) {
                     showToast(R.string.artists_shuffle)

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -142,6 +142,9 @@ object Preferences : KoinComponent {
     val holdTabToSearch: Boolean
         get() = preferences.getBoolean(HOLD_TAB_TO_SEARCH, true)
 
+    val ignoreArticlesWhenSorting: Boolean
+        get() = preferences.getBoolean(IGNORE_ARTICLES_WHEN_SORTING, false)
+
     var lockedPlaylists: Boolean
         get() = preferences.getBoolean(LOCKED_PLAYLISTS, false)
         set(value) = preferences.edit { putBoolean(LOCKED_PLAYLISTS, value) }
@@ -557,6 +560,7 @@ const val LIBRARY_CATEGORIES = "library_categories"
 const val REMEMBER_LAST_PAGE = "remember_last_page"
 const val TAB_TITLES_MODE = "tab_titles_mode"
 const val HOLD_TAB_TO_SEARCH = "hold_tab_to_search"
+const val IGNORE_ARTICLES_WHEN_SORTING = "ignore_articles_when_sorting"
 const val LAST_PAGE = "last_page"
 const val LARGER_HEADER_IMAGE = "larger_header_image"
 const val HORIZONTAL_ARTIST_ALBUMS = "horizontal_artist_albums"

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">حجم الشبكة</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">الترتيب حسب</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">الفنان</string>
     <string name="sort_order_album">ألبوم</string>
     <string name="sort_order_year">السنة</string>

--- a/app/src/main/res/values-be-rBY/strings.xml
+++ b/app/src/main/res/values-be-rBY/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Grid size</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sort by</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>

--- a/app/src/main/res/values-bqi/strings.xml
+++ b/app/src/main/res/values-bqi/strings.xml
@@ -200,7 +200,6 @@
     <string name="action_grid_size">هندا شبکه</string>
     <string name="action_grid_size_land">هندا شبکه (زمین)</string>
     <string name="action_sort_order">ترتیب و ری</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">هونرمند</string>
     <string name="app_language_title">زووݩ برنومه</string>
     <string name="advanced_summary">زووݩ من برنومه ای وو سامووا دیری سی منتورووݩ پؽش رئڌه.</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Mida de la quadrícula</string>
     <string name="action_grid_size_land">Mida de la quadrícula (apaïsada)</string>
     <string name="action_sort_order">Ordena per</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Àlbum</string>
     <string name="sort_order_year">Any</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Velikost mřížky</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Seřadit podle</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Umělec</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Rok</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Gitter størrelse</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sorter efter</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Kunstner</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">År</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Rastergröße</string>
     <string name="action_grid_size_land">Rastergröße (Querformat)</string>
     <string name="action_sort_order">Sortieren nach</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Interpret</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Jahr</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Μέγεθος πλέγματος</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Ταξινόμηση κατά</string>
-    <string name="sort_order_az">Α-Ω</string>
     <string name="sort_order_artist">Καλλιτέχνης</string>
     <string name="sort_order_album">Άλμπουμ</string>
     <string name="sort_order_year">Έτος</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -210,7 +210,6 @@
     <string name="view_type_image">Imagen</string>
     <string name="action_grid_size">Tamaño de cuadrícula</string>
     <string name="action_sort_order">Ordenar por</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Álbum</string>
     <string name="sort_order_year">Año</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Tamaño de la cuadricula</string>
     <string name="action_grid_size_land">Tamaño de la cuadrícula (apaisado)</string>
     <string name="action_sort_order">Ordenar por</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Álbum</string>
     <string name="sort_order_year">Año</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -105,7 +105,6 @@
     <string name="metadata_label">Metateave</string>
     <string name="configure_action">Seadista</string>
     <string name="view_type_image">Pildivaade</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Esitaja</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Aasta</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -226,7 +226,6 @@
     <string name="action_grid_size">اندازه شبکه</string>
     <string name="action_grid_size_land">اندازه شبکه (زمین)</string>
     <string name="action_sort_order">مرتب سازی بر اساس</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">هنرمند</string>
     <string name="sort_order_album">آلبوم</string>
     <string name="sort_order_year">سال</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Ruudukon koko</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Järjestä</string>
-    <string name="sort_order_az">AZ</string>
     <string name="sort_order_artist">Esittäjä</string>
     <string name="sort_order_album">Albumi</string>
     <string name="sort_order_year">Vuosi</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Taille de la grille</string>
     <string name="action_grid_size_land">Taille de la grille (paysage)</string>
     <string name="action_sort_order">Trier par</string>
-    <string name="sort_order_az">A à Z</string>
     <string name="sort_order_artist">Artiste</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Année</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Grid size</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sort by</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">ग्रिड आकार</string>
     <string name="action_grid_size_land">ग्रिड का साइज (जगह)</string>
     <string name="action_sort_order">क्रमबद्ध करें</string>
-    <string name="sort_order_az">A से Z तक</string>
     <string name="sort_order_artist">कलाकार</string>
     <string name="sort_order_album">एल्बम</string>
     <string name="sort_order_year">साल</string>

--- a/app/src/main/res/values-hr-rHR/strings.xml
+++ b/app/src/main/res/values-hr-rHR/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Grid size</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sort by</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Ukuran grid</string>
     <string name="action_grid_size_land">Ukuran grid (lanskap)</string>
     <string name="action_sort_order">Urutkan berdasarkan</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artis</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Tahun</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Dimensione griglia</string>
     <string name="action_grid_size_land">Dimensione griglia (land)</string>
     <string name="action_sort_order">Ordina per</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Anno</string>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">גודל הרשת</string>
     <string name="action_grid_size_land">גודל הרשת (קרקע)</string>
     <string name="action_sort_order">מיון לפי</string>
-    <string name="sort_order_az">א-ת</string>
     <string name="sort_order_artist">אומן</string>
     <string name="sort_order_album">אלבום</string>
     <string name="sort_order_year">שנה</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">グリッドサイズ</string>
     <string name="action_grid_size_land">グリッドサイズ (横)</string>
     <string name="action_sort_order">並び替え</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">アーティスト</string>
     <string name="sort_order_album">アルバム</string>
     <string name="sort_order_year">年</string>

--- a/app/src/main/res/values-kk-rKZ/strings.xml
+++ b/app/src/main/res/values-kk-rKZ/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Grid size</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sort by</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">그리드 크기</string>
     <string name="action_grid_size_land">그리드 크기 (가로)</string>
     <string name="action_sort_order">정렬 기준</string>
-    <string name="sort_order_az">이름순</string>
     <string name="sort_order_artist">아티스트순</string>
     <string name="sort_order_album">앨범순</string>
     <string name="sort_order_year">연도순</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Raster grootte</string>
     <string name="action_grid_size_land">Rooster grootte (land)</string>
     <string name="action_sort_order">Sorteren op</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Kunstenaar</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Jaar</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Størrelse på rutenett</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sorter etter</string>
-    <string name="sort_order_az">A-Å</string>
     <string name="sort_order_artist">Kunstner</string>
     <string name="sort_order_album">album</string>
     <string name="sort_order_year">År</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Rozmiar siatki</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sortuj według</string>
-    <string name="sort_order_az">Nazwa</string>
     <string name="sort_order_artist">Wykonawca</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Rok</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Tamanho da grade</string>
     <string name="action_grid_size_land">Tamanho da grade (horizontal)</string>
     <string name="action_sort_order">Classificar por</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Álbum</string>
     <string name="sort_order_year">Ano</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Tamanho da grade</string>
     <string name="action_grid_size_land">Tamanho da grade (horizontal)</string>
     <string name="action_sort_order">Classificar por</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Álbum</string>
     <string name="sort_order_year">ano</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Dimensiune grilă</string>
     <string name="action_grid_size_land">Grid size (land)</string>
     <string name="action_sort_order">Sortează după</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">An</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Размер сетки</string>
     <string name="action_grid_size_land">Размер сетки (ландшафт)</string>
     <string name="action_sort_order">Сортировать по</string>
-    <string name="sort_order_az">А-Я</string>
     <string name="sort_order_artist">Исполнитель</string>
     <string name="sort_order_album">Альбом</string>
     <string name="sort_order_year">Год</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Storlek på rutnät</string>
     <string name="action_grid_size_land">Rutnätets storlek (land)</string>
     <string name="action_sort_order">Sortera efter</string>
-    <string name="sort_order_az">A-Ö</string>
     <string name="sort_order_artist">Konstnären</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">År</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -226,7 +226,6 @@
     <string name="action_grid_size">கட்ட அளவு</string>
     <string name="action_grid_size_land">கட்ட அளவு (நிலம்)</string>
     <string name="action_sort_order">வரிசைப்படுத்து</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">கலைஞர்</string>
     <string name="sort_order_album">தொகுப்பு</string>
     <string name="sort_order_year">ஆண்டு</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Izgara boyutu</string>
     <string name="action_grid_size_land">Izgara boyutu (yatay)</string>
     <string name="action_sort_order">Sıralama ölçütü</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Sanatçı</string>
     <string name="sort_order_album">Albüm</string>
     <string name="sort_order_year">Yıl</string>

--- a/app/src/main/res/values-tt/strings.xml
+++ b/app/src/main/res/values-tt/strings.xml
@@ -232,7 +232,6 @@
     <string name="lyrics_show_translation_title">Тәрҗемә күрсәтергә</string>
     <string name="action_grid_size">Челтәр күләме</string>
     <string name="action_grid_size_land">Челтәр күләме (ландшафт)</string>
-    <string name="sort_order_az">А-Я</string>
     <string name="sort_order_artist">Артист</string>
     <string name="sort_order_album">Альбом</string>
     <string name="sort_order_year">Ел</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Розмір сітки</string>
     <string name="action_grid_size_land">Розмір сітки (ландшафт)</string>
     <string name="action_sort_order">Сортувати за</string>
-    <string name="sort_order_az">А-Я</string>
     <string name="sort_order_artist">Виконавець</string>
     <string name="sort_order_album">Альбом</string>
     <string name="sort_order_year">Рік</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">Kích thước lưới</string>
     <string name="action_grid_size_land">Kích thước lưới (ngang)</string>
     <string name="action_sort_order">Sắp xếp theo</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">Nghệ sĩ</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Năm</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">网格大小</string>
     <string name="action_grid_size_land">网格大小（横屏）</string>
     <string name="action_sort_order">排序方式</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">艺人</string>
     <string name="sort_order_album">专辑</string>
     <string name="sort_order_year">年份</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -213,7 +213,6 @@
     <string name="action_grid_size">網格大小</string>
     <string name="action_grid_size_land">網格大小（橫向）</string>
     <string name="action_sort_order">排序方式</string>
-    <string name="sort_order_az">A-Z</string>
     <string name="sort_order_artist">藝人</string>
     <string name="sort_order_album">專輯</string>
     <string name="sort_order_year">年份</string>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="action_sort_order_az" type="id"/>
+    <item name="action_sort_order_name" type="id"/>
     <item name="action_sort_order_artist" type="id"/>
     <item name="action_sort_order_album" type="id"/>
     <item name="action_sort_order_duration" type="id"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,7 +238,7 @@
     <string name="grid_size_7" translatable="false">7</string>
     <string name="grid_size_8" translatable="false">8</string>
     <string name="action_sort_order">Sort by</string>
-    <string name="sort_order_az">A-Z</string>
+    <string name="sort_order_name">Name</string>
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>


### PR DESCRIPTION
Adds numeric-aware (locale-aware) sorting.
Names such as `Track 2`, `Track 10` now appear in natural order.

- Used Android ICU for this.
- Applied to libraries, folders, filenames, playlist names, and name pickers
- Added tie-breakers for equal values
- Made recursive folder use the selected folder-song sort order: Would use the same order as MediaStore before
- Renamed the sort keywords from A–Z/Title to Name
- Also reused article-matching regexes

Closes #503 and closes #494

## Summary by Sourcery

Implement natural, locale-aware name sorting with numeric collation for songs, albums, artists, genres, playlists, folders, and related UI, while unifying sort configuration and keeping behavior consistent across views.

New Features:
- Add locale-aware, numeric-aware collator-based sorting for names across media entities and UI name pickers.

Bug Fixes:
- Ensure recursive folder views use the same song sort order as non-recursive folder views.
- Provide deterministic tie-breaking by name for sorts using non-name keys such as track number, duration, dates, and counts.

Enhancements:
- Introduce shared sorting utilities and collator configuration to centralize name and media-name sorting logic.
- Reuse precomputed article-matching regexes when normalizing titles for sorting to reduce repeated allocations.
- Rename the generic A–Z/Title sort option to Name in sort keys, menu IDs, and user-facing strings while preserving stored preferences.