### PR TITLE
Update about and sheet visibility

### DIFF
--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsSlidingMusicPanelActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsSlidingMusicPanelActivity.kt
@@ -79,10 +79,8 @@ import com.mardous.booming.extensions.resources.peekHeightAnimate
 import com.mardous.booming.extensions.resources.show
 import com.mardous.booming.extensions.whichFragment
 import com.mardous.booming.ui.IBackConsumer
-import com.mardous.booming.ui.screen.info.PlayInfoFragment
 import com.mardous.booming.ui.screen.library.LibraryViewModel
 import com.mardous.booming.ui.screen.library.search.SearchFragment
-import com.mardous.booming.ui.screen.lyrics.LyricsEditorFragment
 import com.mardous.booming.ui.screen.lyrics.LyricsViewModel
 import com.mardous.booming.ui.screen.other.MiniPlayerFragment
 import com.mardous.booming.ui.screen.permissions.PermissionsActivity
@@ -153,6 +151,10 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
     val isBottomSheetHidden: Boolean
         get() = panelState == STATE_COLLAPSED && bottomSheetBehavior.peekHeight == 0
 
+    /** Set by destinations that want no sheet. Stored as a var,
+     because reopening (e.g. external links), used to reset this value */
+    private var keepBottomSheetHidden = false
+
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             if (handleBackPress()) {
@@ -197,9 +199,7 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
 
         launchAndRepeatWithViewLifecycle {
             playerViewModel.queueFlow.collect { queue ->
-                val currentFragment = currentFragment(R.id.fragment_container)
-                if (currentFragment !is LyricsEditorFragment &&
-                    currentFragment !is PlayInfoFragment) {
+                if (!keepBottomSheetHidden) {
                     hideBottomSheet(queue.isEmpty())
                 }
             }
@@ -301,10 +301,12 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
     fun setBottomNavVisibility(
         visible: Boolean,
         animate: Boolean = false,
-        hideBottomSheet: Boolean = playerViewModel.queue.isEmpty(),
+        hideBottomSheet: Boolean? = null,
     ) {
+        keepBottomSheetHidden = (hideBottomSheet == true)
+        val hide = hideBottomSheet ?: playerViewModel.queue.isEmpty()
         if (isInOneTabMode) {
-            hideBottomSheet(hide = hideBottomSheet, animate = animate, isBottomNavVisible = false)
+            hideBottomSheet(hide = hide, animate = animate, isBottomNavVisible = false)
             return
         }
         val isBottomNavView = (navigationView is BottomNavigationView)
@@ -325,7 +327,7 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
             }
         }
         hideBottomSheet(
-            hide = hideBottomSheet,
+            hide = hide,
             animate = animate,
             isBottomNavVisible = visible && navigationView is BottomNavigationView
         )

--- a/app/src/main/java/com/mardous/booming/ui/component/base/AbsSlidingMusicPanelActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/component/base/AbsSlidingMusicPanelActivity.kt
@@ -151,9 +151,11 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
     val isBottomSheetHidden: Boolean
         get() = panelState == STATE_COLLAPSED && bottomSheetBehavior.peekHeight == 0
 
-    /** Set by destinations that want no sheet. Stored as a var,
-     because reopening (e.g. external links), used to reset this value */
-    private var keepBottomSheetHidden = false
+    /**
+     * Set while a destination is holding the sheet down.
+     * Queue changes must not slide the mini player back in until the next destination.
+     */
+    private var isHiddenByDestination = false
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -199,7 +201,7 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
 
         launchAndRepeatWithViewLifecycle {
             playerViewModel.queueFlow.collect { queue ->
-                if (!keepBottomSheetHidden) {
+                if (!isHiddenByDestination) {
                     hideBottomSheet(queue.isEmpty())
                 }
             }
@@ -298,12 +300,15 @@ abstract class AbsSlidingMusicPanelActivity : AbsBaseActivity(),
         })
     }
 
+    /**
+     * @param hideBottomSheet `true` hides the sheet. `null` lets the queue decide
+     */
     fun setBottomNavVisibility(
         visible: Boolean,
         animate: Boolean = false,
         hideBottomSheet: Boolean? = null,
     ) {
-        keepBottomSheetHidden = (hideBottomSheet == true)
+        isHiddenByDestination = (hideBottomSheet == true)
         val hide = hideBottomSheet ?: playerViewModel.queue.isEmpty()
         if (isInOneTabMode) {
             hideBottomSheet(hide = hide, animate = animate, isBottomNavVisible = false)

--- a/app/src/main/java/com/mardous/booming/ui/screen/about/AboutScreen.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/about/AboutScreen.kt
@@ -19,6 +19,7 @@ package com.mardous.booming.ui.screen.about
 
 import android.content.Intent
 import android.content.pm.PackageManager
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -93,10 +94,13 @@ import com.mardous.booming.util.Constants.DONATION_LINK
 import com.mardous.booming.util.Constants.DOWNLOAD_URL
 import com.mardous.booming.util.Constants.FAQ_LINK
 import com.mardous.booming.util.Constants.ISSUE_TRACKER_LINK
+import com.mardous.booming.util.Constants.PRIVACY_POLICY_LINK
 import com.mardous.booming.util.Constants.RELEASES_LINK
 import com.mardous.booming.util.Constants.SUPPORT_EMAIL
 import com.mardous.booming.util.Constants.TELEGRAM_LINK
+import com.mardous.booming.util.Constants.TERMS_OF_SERVICE_LINK
 import com.mardous.booming.util.Constants.TRANSLATIONS_LINK
+import com.mardous.booming.util.Constants.WEBSITE_LINK
 import com.mikepenz.aboutlibraries.ui.compose.android.produceLibraries
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import dev.jeziellago.compose.markdowntext.MarkdownText
@@ -170,7 +174,8 @@ fun AboutScreen(
     }
 
     val sections = getAboutSections(
-        onTranslatorsClick = { showTranslatorsDialog = true }
+        onTranslatorsClick = { showTranslatorsDialog = true },
+        onLicensesClick = { showLicensesDialog = true }
     )
 
     CollapsibleAppBarScaffold(
@@ -184,15 +189,7 @@ fun AboutScreen(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(ListItemDefaults.SegmentedGap)
         ) {
-            item {
-                BoomingMusicHeader(
-                    version = appVersion,
-                    onChangelogClick = { context.openUrl(RELEASES_LINK) },
-                    onForkClick = { context.openUrl(APP_GITHUB_URL) },
-                    onFAQClick = { context.openUrl(FAQ_LINK) },
-                    onLicensesClick = { showLicensesDialog = true }
-                )
-            }
+            item { BoomingMusicHeader(version = appVersion) }
 
             item { AboutSectionTitle(stringResource(R.string.author)) }
 
@@ -229,13 +226,8 @@ fun AboutScreen(
 }
 
 @Composable
-private fun BoomingMusicHeader(
-    version: String,
-    onChangelogClick: () -> Unit,
-    onForkClick: () -> Unit,
-    onLicensesClick: () -> Unit,
-    onFAQClick: () -> Unit
-) {
+private fun BoomingMusicHeader(version: String) {
+    val context = LocalContext.current
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxWidth()
@@ -298,7 +290,7 @@ private fun BoomingMusicHeader(
                     icon = R.drawable.ic_history_24dp,
                     label = stringResource(R.string.changelog),
                     modifier = Modifier.weight(1f),
-                    onClick = onChangelogClick
+                    onClick = { context.openUrl(RELEASES_LINK) }
                 )
             }
 
@@ -306,21 +298,21 @@ private fun BoomingMusicHeader(
                 icon = R.drawable.ic_github_circle_24dp,
                 label = stringResource(R.string.github),
                 modifier = Modifier.weight(1f),
-                onClick = onForkClick
+                onClick = { context.openUrl(APP_GITHUB_URL) }
             )
 
             AboutHeaderButton(
                 icon = R.drawable.ic_help_24dp,
                 label = stringResource(R.string.faq),
                 modifier = Modifier.weight(1f),
-                onClick = onFAQClick
+                onClick = { context.openUrl(FAQ_LINK) }
             )
 
             AboutHeaderButton(
-                icon = R.drawable.ic_description_24dp,
-                label = stringResource(R.string.licenses),
+                icon = R.drawable.ic_language_24dp,
+                label = stringResource(R.string.website),
                 modifier = Modifier.weight(1f),
-                onClick = onLicensesClick
+                onClick = { context.openUrl(WEBSITE_LINK) }
             )
         }
     }
@@ -492,9 +484,24 @@ private fun AboutHeaderButton(
     }
 }
 
+/** Table of all contributors */
+private enum class Contributor(
+    @StringRes val title: Int,
+    @StringRes val description: Int,
+    val avatar: String,
+    val githubUser: String
+) {
+    Dawid(R.string.contributor_dawid, R.string.contributor_dawid_description, "dawid", "hackzy01"),
+    Lenard(R.string.contributor_lenard, R.string.contributor_lenard_description, "lenard", "lenardflx"),
+    TTop(R.string.contributor_ttop, R.string.contributor_ttop_description, "ttop", "TheTerminatorOfProgramming"),
+    Ray(R.string.contributor_ray, R.string.contributor_ray_description, "ray", "raycadle"),
+    Alex(R.string.contributor_alex, R.string.contributor_alex_description, "alex", "Paxsenix0")
+}
+
 @Composable
 private fun getAboutSections(
-    onTranslatorsClick: () -> Unit
+    onTranslatorsClick: () -> Unit,
+    onLicensesClick: () -> Unit
 ): List<Pair<String, List<AboutItemData>>> {
     val context = LocalContext.current
 
@@ -506,62 +513,19 @@ private fun getAboutSections(
     }
 
     return listOf(
-        stringResource(R.string.contributors) to listOf(
+        stringResource(R.string.contributors) to Contributor.entries.map { contributor ->
             AboutItemData(
                 icon = {
                     AboutContributorImage(
-                        username = "dawid",
+                        username = contributor.avatar,
                         modifier = Modifier.size(48.dp)
                     )
                 },
-                title = stringResource(R.string.contributor_dawid),
-                summary = stringResource(R.string.contributor_dawid_description),
-                onClick = { openGithubProfile("hackzy01") }
-            ),
-            AboutItemData(
-                icon = {
-                    AboutContributorImage(
-                        username = "lenard",
-                        modifier = Modifier.size(48.dp)
-                    )
-                },
-                title = stringResource(R.string.contributor_lenard),
-                summary = stringResource(R.string.contributor_lenard_description),
-                onClick = { openGithubProfile("lenardflx") }
-            ),
-            AboutItemData(
-                icon = {
-                    AboutContributorImage(
-                        username = "ttop",
-                        modifier = Modifier.size(48.dp)
-                    )
-                },
-                title = stringResource(R.string.contributor_ttop),
-                summary = stringResource(R.string.contributor_ttop_description),
-                onClick = { openGithubProfile("TheTerminatorOfProgramming") }
-            ),
-            AboutItemData(
-                icon = {
-                    AboutContributorImage(
-                        username = "ray",
-                        modifier = Modifier.size(48.dp)
-                    )
-                },
-                title = stringResource(R.string.contributor_ray),
-                summary = stringResource(R.string.contributor_ray_description),
-                onClick = { openGithubProfile("raycadle") }
-            ),
-            AboutItemData(
-                icon = {
-                    AboutContributorImage(
-                        username = "alex",
-                        modifier = Modifier.size(48.dp)
-                    )
-                },
-                title = stringResource(R.string.contributor_alex),
-                summary = stringResource(R.string.contributor_alex_description),
-                onClick = { openGithubProfile("Paxsenix0") }
-            ),
+                title = stringResource(contributor.title),
+                summary = stringResource(contributor.description),
+                onClick = { openGithubProfile(contributor.githubUser) }
+            )
+        } + listOf(
             AboutItemData(
                 icon = { AboutItemIcon(painterResource(R.drawable.ic_translate_24dp)) },
                 title = stringResource(R.string.translators_title),
@@ -606,6 +570,23 @@ private fun getAboutSections(
                             .toChooser(sendInvitationTitle)
                     )
                 }
+            )
+        ),
+        stringResource(R.string.legal) to listOf(
+            AboutItemData(
+                icon = { AboutItemIcon(painterResource(R.drawable.ic_description_24dp)) },
+                title = stringResource(R.string.licenses),
+                onClick = onLicensesClick
+            ),
+            AboutItemData(
+                icon = { AboutItemIcon(painterResource(R.drawable.ic_description_24dp)) },
+                title = stringResource(R.string.terms_of_service),
+                onClick = { context.openUrl(TERMS_OF_SERVICE_LINK) }
+            ),
+            AboutItemData(
+                icon = { AboutItemIcon(painterResource(R.drawable.ic_description_24dp)) },
+                title = stringResource(R.string.privacy_policy),
+                onClick = { context.openUrl(PRIVACY_POLICY_LINK) }
             )
         )
     )

--- a/app/src/main/java/com/mardous/booming/util/Constants.kt
+++ b/app/src/main/java/com/mardous/booming/util/Constants.kt
@@ -32,6 +32,9 @@ object Constants {
     const val FAQ_LINK = "$APP_GITHUB_URL/wiki/FAQ"
     const val TRANSLATIONS_LINK = "https://hosted.weblate.org/engage/booming-music/"
     const val TELEGRAM_LINK = "https://t.me/mardousdev"
+    const val WEBSITE_LINK = "https://www.boomingmusic.org"
+    const val TERMS_OF_SERVICE_LINK = "$WEBSITE_LINK/terms-of-service"
+    const val PRIVACY_POLICY_LINK = "$WEBSITE_LINK/privacy-policy"
 
     // External Links
     const val DOWNLOAD_URL = BuildConfig.DOWNLOAD_URL

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -590,7 +590,11 @@
     <string name="changelog">Changelog</string>
     <string name="github">GitHub</string>
     <string name="faq">FAQ</string>
+    <string name="website">Website</string>
     <string name="licenses">Licenses</string>
+    <string name="legal">Legal</string>
+    <string name="terms_of_service">Terms of Service</string>
+    <string name="privacy_policy">Privacy Policy</string>
     <string name="author">Author</string>
     <string name="mardous_summary">Lead Developer</string>
     <string name="contributors">Contributors</string>


### PR DESCRIPTION
Added a Legal section, moved Licenses there and our Terms of Service / Privacy Policy
Old spot of Licenses became a Website button

Fixed: mini player reappeared on link-out and back by adding a persistant var

Cleaned:
- BoomingMusicHeader's callbacks were all context.openUrl(CONST), now inlined
- contributors become a Contributor enum instead of five big blocks

## Summary by Sourcery

Restructure the About screen to add a dedicated Legal section and improve contributor and header configuration while fixing bottom sheet visibility when returning from external links.

New Features:
- Add a Website button to the About header linking to the project site.
- Introduce a Legal section in the About screen containing Licenses, Terms of Service, and Privacy Policy entries.

Bug Fixes:
- Preserve the hidden state of the bottom sheet / mini player when navigating out of and back into the app by tracking sheet visibility with a persistent flag.

Enhancements:
- Refactor the About header to inline URL-opening behavior instead of passing callbacks from the screen.
- Replace duplicated contributor definitions with a Contributor enum used to generate the contributors list.
- Add constants and string resources for the website, terms of service, privacy policy, and legal section labels.