### PR TITLE
Widget bug fixes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -86,3 +86,6 @@
 # Hide an annoying compilation warning
 # http://stackoverflow.com/questions/3308010/what-is-the-ignoring-innerclasses-attribute-warning-output-during-compilation
 -keepattributes EnclosingMethod
+
+# Prevent R8 from merging widget classes and mixing their IDs.
+-keepnames class com.mardous.booming.core.appwidgets.widget.**

--- a/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetActionReceiver.kt
+++ b/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetActionReceiver.kt
@@ -11,9 +11,7 @@ import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionToken
 import com.mardous.booming.playback.Playback
 import com.mardous.booming.playback.PlaybackService
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -23,8 +21,6 @@ import kotlin.time.Duration.Companion.milliseconds
 private const val TAG = "WidgetActionReceiver"
 
 private const val CONNECT_TIMEOUT_MS = 5_000L
-
-private val widgetScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 /** Where widget buttons land */
 class WidgetActionReceiver : BroadcastReceiver() {

--- a/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetPresenter.kt
+++ b/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetPresenter.kt
@@ -10,6 +10,7 @@ import androidx.core.content.getSystemService
 import com.mardous.booming.core.appwidgets.component.progressTickInterval
 import com.mardous.booming.core.appwidgets.state.PlaybackState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -83,6 +84,13 @@ class WidgetPresenter(
     fun refresh() {
         syncTicker()
         refreshJob?.cancel()
+        // Push immediately: service teardown can cancel a debounced stop update.
+        if (!playback.isPlaying) {
+            widgetScope.launch(Dispatchers.Main) {
+                WidgetUpdater.push(context) { needs -> playback.snapshot(needs) }
+            }
+            return
+        }
         refreshJob = scope.launch {
             delay(REFRESH_DEBOUNCE)
             WidgetUpdater.push(context) { needs -> playback.snapshot(needs) }

--- a/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetUpdater.kt
+++ b/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetUpdater.kt
@@ -45,8 +45,10 @@ object WidgetUpdater {
             for ((receiverName, widget) in widgetsByReceiver) {
                 val component = ComponentName(context, receiverName)
                 for (appWidgetId in appWidgetManager.getAppWidgetIds(component)) {
+                    // Throws if the widget was removed since the id lookup
+                    val glanceId = runCatching { manager.getGlanceIdBy(appWidgetId) }
+                        .getOrNull() ?: continue
                     val config = WidgetConfigStore.read(context, appWidgetId, widget.settings)
-                    val glanceId = manager.getGlanceIdBy(appWidgetId)
                     add(Placed(widget, glanceId, config.dataNeeds(widget.settings)))
                 }
             }

--- a/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetUpdater.kt
+++ b/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetUpdater.kt
@@ -11,10 +11,15 @@ import com.mardous.booming.core.appwidgets.config.WidgetConfigStore
 import com.mardous.booming.core.appwidgets.state.PlaybackState
 import com.mardous.booming.core.appwidgets.state.PlaybackStateDefinition
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+
+/** Survives service shutdown for pending widget writes. */
+internal val widgetScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 object WidgetUpdater {
 

--- a/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetUpdater.kt
+++ b/app/src/main/java/com/mardous/booming/core/appwidgets/WidgetUpdater.kt
@@ -1,6 +1,7 @@
 package com.mardous.booming.core.appwidgets
 
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -30,21 +31,22 @@ object WidgetUpdater {
 
     private val renderLock = Mutex()
 
-    private val widgets = widgetsByReceiver.values
-
     private class Placed(
         val widget: BoomingWidget,
         val glanceId: GlanceId,
         val needs: Set<WidgetData>
     )
 
-    private suspend fun placed(context: Context): List<Placed> {
+    /** Resolves widgets by receiver because R8 can merge widget classes. */
+    private fun placed(context: Context): List<Placed> {
+        val appWidgetManager = AppWidgetManager.getInstance(context)
         val manager = GlanceAppWidgetManager(context)
         return buildList {
-            for (widget in widgets) {
-                for (glanceId in manager.getGlanceIds(widget.javaClass)) {
-                    val appWidgetId = manager.getAppWidgetId(glanceId)
+            for ((receiverName, widget) in widgetsByReceiver) {
+                val component = ComponentName(context, receiverName)
+                for (appWidgetId in appWidgetManager.getAppWidgetIds(component)) {
                     val config = WidgetConfigStore.read(context, appWidgetId, widget.settings)
+                    val glanceId = manager.getGlanceIdBy(appWidgetId)
                     add(Placed(widget, glanceId, config.dataNeeds(widget.settings)))
                 }
             }


### PR DESCRIPTION
## Description
Fixes two widget bugs:

1. Widgets could stay stuck on the pause icon after closing the app.
2. The cookie widget could render as the circle widget in release builds due to R8 merging widget classes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no functional changes)
- [ ] Performance optimization
- [ ] Documentation update

## AI Agent Usage Disclosure
- [x] **I used an AI agent (e.g., Gemini, Claude, ChatGPT) to assist with this code.**
  - Claude, for debugging both issues. Reviewed and adjusted by hand.
- [ ] I did NOT use an AI agent for this contribution.

## Checklist
- [x] My code follows the project's coding style and guidelines.
- [x] I have verified that my changes do not compromise user experience or performance

## Screenshots / Videos (if applicable)
N/A

## Summary by Sourcery

Fix widget playback state updates and prevent widget type mix-ups in release builds.

Bug Fixes:
- Ensure non-playing widgets push an immediate state update on refresh to avoid staying stuck on the pause icon after service teardown.
- Resolve widget misconfiguration in release builds by mapping app widget IDs via receiver components to the correct widget definitions and updating Proguard/R8 rules to stop widget class merging.