### PR TITLE
Fix startup crash when applying a shuffle order (#528)

### DIFF
--- a/app/src/main/java/com/mardous/booming/playback/ImprovedShuffleOrder.kt
+++ b/app/src/main/java/com/mardous/booming/playback/ImprovedShuffleOrder.kt
@@ -188,13 +188,14 @@ class ImprovedShuffleOrder private constructor(
             return shuffled
         }
 
+        /** An unusable [firstIndex] leaves the order unrotated rather than throwing. */
         private fun calculateListWithFirstIndex(shuffled: IntArray, firstIndex: Int): IntArray {
-            if (shuffled.isEmpty() && firstIndex == 0) return shuffled
-            if (shuffled.size <= firstIndex) throw IllegalArgumentException("${shuffled.size} <= $firstIndex")
             val fi = shuffled.indexOf(firstIndex)
-            val before = shuffled.slice(0..<fi)
-            val inclAndAfter = shuffled.slice(fi..<shuffled.size)
-            return (inclAndAfter + before).toIntArray()
+            if (fi <= 0) return shuffled
+            val rotated = IntArray(shuffled.size)
+            shuffled.copyInto(rotated, 0, fi)
+            shuffled.copyInto(rotated, shuffled.size - fi, 0, fi)
+            return rotated
         }
     }
 }

--- a/app/src/main/java/com/mardous/booming/playback/ImprovedShuffleOrder.kt
+++ b/app/src/main/java/com/mardous/booming/playback/ImprovedShuffleOrder.kt
@@ -1,5 +1,6 @@
 package com.mardous.booming.playback
 
+import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.source.ShuffleOrder
@@ -177,6 +178,8 @@ class ImprovedShuffleOrder private constructor(
     }
 
     companion object {
+        private const val TAG = "ImprovedShuffleOrder"
+
         private fun calculateShuffledList(offset: Int, length: Int, random: Random): IntArray {
             val shuffled = IntArray(length)
             var swapIndex: Int
@@ -191,6 +194,9 @@ class ImprovedShuffleOrder private constructor(
         /** An unusable [firstIndex] leaves the order unrotated rather than throwing. */
         private fun calculateListWithFirstIndex(shuffled: IntArray, firstIndex: Int): IntArray {
             val fi = shuffled.indexOf(firstIndex)
+            if (fi < 0 && shuffled.isNotEmpty()) {
+                Log.w(TAG, "Ignored out-of-range firstIndex=$firstIndex (length=${shuffled.size})")
+            }
             if (fi <= 0) return shuffled
             val rotated = IntArray(shuffled.size)
             shuffled.copyInto(rotated, 0, fi)

--- a/app/src/main/java/com/mardous/booming/playback/PlaybackExtension.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackExtension.kt
@@ -2,6 +2,7 @@ package com.mardous.booming.playback
 
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -9,6 +10,8 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ShuffleOrder
 import androidx.media3.session.MediaConstants
 import androidx.media3.session.MediaSession
 import com.mardous.booming.coil.CoverProvider
@@ -18,6 +21,9 @@ import com.mardous.booming.data.model.Song
 import com.mardous.booming.extensions.media.songInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.random.Random
+
+private const val TAG = "PlaybackExtension"
 
 /**
  * Extra parameter indicating when a MediaItem was generated from a Song
@@ -84,6 +90,29 @@ fun Player.removeMediaItemsById(ids: Set<String>) {
     for (index in mediaItemCount - 1 downTo 0) {
         if (getMediaItemAt(index).mediaId in ids) removeMediaItem(index)
     }
+}
+
+/** The player validates against an internal count we cannot read: a dropped order is harmless, a crash is not. */
+@OptIn(UnstableApi::class)
+internal fun ExoPlayer.applyShuffleOrder(order: ShuffleOrder) {
+    try {
+        shuffleOrder = order
+    } catch (e: IllegalArgumentException) {
+        Log.w(TAG, "Rejected shuffle order: length=${order.length}, items=$mediaItemCount", e)
+    }
+}
+
+/** Reshuffles the current queue, keeping the current item first. */
+@OptIn(UnstableApi::class)
+internal fun ExoPlayer.applyRandomShuffleOrder() {
+    val itemCount = mediaItemCount
+    applyShuffleOrder(
+        ImprovedShuffleOrder(
+            firstIndex = currentMediaItemIndex.coerceIn(0, maxOf(itemCount - 1, 0)),
+            length = itemCount,
+            randomSeed = Random.nextLong()
+        )
+    )
 }
 
 val MediaItem.resolvedFromFile: Boolean

--- a/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
@@ -43,6 +43,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.ShuffleOrder
 import androidx.media3.exoplayer.source.ShuffleOrder.UnshuffledShuffleOrder
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.mp3.Mp3Extractor
@@ -304,7 +305,7 @@ class PlaybackService :
                 .build()
         )
 
-        player.exoPlayer.shuffleOrder = ImprovedShuffleOrder(0, 0, Random.nextLong())
+        player.exoPlayer.applyShuffleOrder(ImprovedShuffleOrder(0, 0, Random.nextLong()))
         player.setSequentialTimelineEnabled(sequentialTimeline)
         player.addListener(this)
 
@@ -333,7 +334,7 @@ class PlaybackService :
             player.setMediaItems(items.mediaItems, items.startIndex, items.startPositionMs)
             player.prepare()
             if (player.shuffleModeEnabled && shuffleOrder != null) {
-                player.exoPlayer.shuffleOrder = shuffleOrder
+                player.exoPlayer.applyShuffleOrder(shuffleOrder)
             }
         }
 
@@ -607,11 +608,7 @@ class PlaybackService :
     ): ListenableFuture<MediaItemsWithStartPosition> {
         player.exoPlayer.let { exoPlayer ->
             if (exoPlayer.shuffleOrder !is ImprovedShuffleOrder && !hasSetUnshuffledOrder) {
-                exoPlayer.shuffleOrder = ImprovedShuffleOrder(
-                    firstIndex = player.currentMediaItemIndex,
-                    length = player.mediaItemCount,
-                    randomSeed = Random.nextLong()
-                )
+                exoPlayer.applyRandomShuffleOrder()
             }
 
             (exoPlayer.shuffleOrder as? ImprovedShuffleOrder)
@@ -714,7 +711,7 @@ class PlaybackService :
 
             Playback.SET_UNSHUFFLED_ORDER -> {
                 hasSetUnshuffledOrder = true
-                player.exoPlayer.shuffleOrder = UnshuffledShuffleOrder(player.mediaItemCount)
+                with(player.exoPlayer) { applyShuffleOrder(UnshuffledShuffleOrder(mediaItemCount)) }
                 Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
             }
 
@@ -754,7 +751,7 @@ class PlaybackService :
             persistentStorage.waitForMediaItems { items, shuffleOrder ->
                 if (items.mediaItems.isNotEmpty()) {
                     if (player.shuffleModeEnabled && shuffleOrder != null) {
-                        player.exoPlayer.shuffleOrder = shuffleOrder
+                        player.exoPlayer.applyShuffleOrder(shuffleOrder)
                     }
                     settableFuture.set(items)
                 } else {
@@ -910,11 +907,11 @@ class PlaybackService :
             if (!events.contains(Player.EVENT_TIMELINE_CHANGED)) {
                 dispatchPlayQueue(player)
                 if (player.shuffleModeEnabled && persistentStorage.restorationState.isRestored) {
-                    this.player.exoPlayer.shuffleOrder = ImprovedShuffleOrder(
-                        firstIndex = player.currentMediaItemIndex,
-                        length = player.mediaItemCount,
-                        randomSeed = Random.nextLong()
-                    )
+                    val exoPlayer = this.player.exoPlayer
+                    // Keep the staged start index while the queue is empty.
+                    if (exoPlayer.mediaItemCount > 0) {
+                        exoPlayer.applyRandomShuffleOrder()
+                    }
                 }
             }
         }
@@ -976,6 +973,26 @@ class PlaybackService :
                 player.exoPlayer.setSeekForwardIncrementMs(seekInterval)
             }
         }
+    }
+
+    /** The player validates against an internal count we cannot read: a dropped order is harmless, a crash is not. */
+    private fun ExoPlayer.applyShuffleOrder(order: ShuffleOrder) {
+        try {
+            shuffleOrder = order
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Rejected shuffle order: length=${order.length}, items=$mediaItemCount", e)
+        }
+    }
+
+    private fun ExoPlayer.applyRandomShuffleOrder() {
+        val itemCount = mediaItemCount
+        applyShuffleOrder(
+            ImprovedShuffleOrder(
+                firstIndex = currentMediaItemIndex.coerceIn(0, maxOf(itemCount - 1, 0)),
+                length = itemCount,
+                randomSeed = Random.nextLong()
+            )
+        )
     }
 
     private fun toggleShuffle() {

--- a/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
@@ -43,7 +43,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
-import androidx.media3.exoplayer.source.ShuffleOrder
 import androidx.media3.exoplayer.source.ShuffleOrder.UnshuffledShuffleOrder
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.mp3.Mp3Extractor
@@ -973,26 +972,6 @@ class PlaybackService :
                 player.exoPlayer.setSeekForwardIncrementMs(seekInterval)
             }
         }
-    }
-
-    /** The player validates against an internal count we cannot read: a dropped order is harmless, a crash is not. */
-    private fun ExoPlayer.applyShuffleOrder(order: ShuffleOrder) {
-        try {
-            shuffleOrder = order
-        } catch (e: IllegalArgumentException) {
-            Log.w(TAG, "Rejected shuffle order: length=${order.length}, items=$mediaItemCount", e)
-        }
-    }
-
-    private fun ExoPlayer.applyRandomShuffleOrder() {
-        val itemCount = mediaItemCount
-        applyShuffleOrder(
-            ImprovedShuffleOrder(
-                firstIndex = currentMediaItemIndex.coerceIn(0, maxOf(itemCount - 1, 0)),
-                length = itemCount,
-                randomSeed = Random.nextLong()
-            )
-        )
     }
 
     private fun toggleShuffle() {


### PR DESCRIPTION
## Description

Closes #528, a startup crash caused when Media3 rejects a shuffle order during a queue update.

- Route shuffle-order updates through a safe helper that logs rejected orders instead of crashing.
- Leave invalid starting indices unrotated rather than throwing.
- Preserve existing shuffle behaviour, including reshuffling when shuffle is toggled.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no functional changes)
- [ ] Performance optimization
- [ ] Documentation update

## AI Agent Usage Disclosure
- [x] **I used an AI agent (e.g., Gemini, Claude, ChatGPT) to assist with this code.**
  - Claude Code: traced obfuscated report, diagnosed fail, helped coding;
  - Reviewed and verified on device, by hand.
- [ ] I did NOT use an AI agent for this contribution.

## Checklist
- [x] My code follows the project's coding style and guidelines.
- [x] I have verified that my changes do not compromise user experience or performance

## Screenshots / Videos (if applicable)

No UI changes.

## Summary by Sourcery

Prevent player startup crashes by safely applying and logging rejected shuffle orders and by handling invalid starting indices without exceptions.

Bug Fixes:
- Avoid crashes when Media3 rejects shuffle orders by routing assignments through a safe helper that logs and ignores invalid orders.
- Prevent crashes from invalid shuffle starting indices by leaving the shuffle order unrotated instead of throwing.

Enhancements:
- Introduce helper methods on ExoPlayer to apply shuffle orders and random shuffle state while preserving existing shuffle behaviour, including reshuffling on toggle.