### PR TITLE
fix(avrcp): can not play selected track

### DIFF
--- a/app/src/main/java/com/mardous/booming/playback/library/LibraryProvider.kt
+++ b/app/src/main/java/com/mardous/booming/playback/library/LibraryProvider.kt
@@ -85,9 +85,12 @@ class LibraryProvider(private val repository: Repository) {
                     val results = searchResult(callerUid)
                     if (id == null || results.isEmpty()) return null
                     val transformedMediaItems = results.map { it.buildUpon().setMediaId(id).build() }
+                    val correctIndex = transformedMediaItems.indexOfFirst { it.mediaId == id }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
                     MediaItemsWithStartPosition(
                         transformedMediaItems,
-                        transformedMediaItems.indexOfFirst { it.mediaId == id }.coerceAtLeast(0),
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
@@ -95,85 +98,114 @@ class LibraryProvider(private val repository: Repository) {
                 MediaIDs.SONGS -> {
                     val id = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val allSongs = repository.allSongs()
+                    val correctIndex = allSongs.indexOfFirst { it.id == id }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
                     MediaItemsWithStartPosition(
                         allSongs.map { it.toPlayableMediaItem() },
-                        allSongs.indexOfFirst { it.id == id }.coerceAtLeast(0),
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                
                 MediaIDs.ALBUMS -> {
                     val albumId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val songId = path.getOrNull(2)?.toLongOrNull() ?: return null
                     val album = repository.albumById(albumId)
+                    val correctIndex = album.songs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+                    val parentId = MediaIDs.getPathId(MediaIDs.ALBUMS, albumId)
                     MediaItemsWithStartPosition(
-                        album.songs.map { it.toPlayableMediaItem() },
-                        album.songs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        album.songs.map { it.toPlayableMediaItem(parentId) },
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                
                 MediaIDs.ARTISTS -> {
                     val songId = path.getOrNull(2)?.toLongOrNull() ?: return null
                     val artistId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val artistSongs = repository.artistById(artistId).sortedSongs
+                    val correctIndex = artistSongs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+                    val parentId = MediaIDs.getPathId(MediaIDs.ARTISTS, artistId)
                     MediaItemsWithStartPosition(
-                        artistSongs.map { it.toPlayableMediaItem() },
-                        artistSongs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        artistSongs.map { it.toPlayableMediaItem(parentId) },
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                
                 MediaIDs.ALBUM_ARTISTS -> {
                     val songId = path.getOrNull(2)?.toLongOrNull() ?: return null
                     val albumArtistName = path.getOrNull(1) ?: return null
-                    val albumArtistSongs =
-                        repository.albumArtistByName(albumArtistName).sortedSongs
+                    val albumArtistSongs = repository.albumArtistByName(albumArtistName).sortedSongs
+                    val correctIndex = albumArtistSongs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+                    val parentId = MediaIDs.getPathId(MediaIDs.ALBUM_ARTISTS, albumArtistName)
                     MediaItemsWithStartPosition(
-                        albumArtistSongs.map { it.toPlayableMediaItem() },
-                        albumArtistSongs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        albumArtistSongs.map { it.toPlayableMediaItem(parentId) },
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                
                 MediaIDs.PLAYLISTS -> {
                     val songId = path.getOrNull(2)?.toLongOrNull() ?: return null
                     val playlistId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val playlist = repository.playlistWithSongs(playlistId)
+                    val correctIndex = playlist.songs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+                    val parentId = MediaIDs.getPathId(MediaIDs.PLAYLISTS, playlistId)
                     MediaItemsWithStartPosition(
-                        playlist.songs.toSongs().map { it.toPlayableMediaItem() },
-                        playlist.songs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        playlist.songs.toSongs().map { it.toPlayableMediaItem(parentId) },
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                
                 MediaIDs.GENRES -> {
                     val songId = path.getOrNull(2)?.toLongOrNull() ?: return null
                     val genreId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val songsByGenre = repository.songsByGenre(genreId)
+                    val correctIndex = songsByGenre.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+                    val parentId = MediaIDs.getPathId(MediaIDs.GENRES, genreId)
                     MediaItemsWithStartPosition(
-                        songsByGenre.map { it.toPlayableMediaItem() },
-                        songsByGenre.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        songsByGenre.map { it.toPlayableMediaItem(parentId) },
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                                
                 MediaIDs.TOP_TRACKS -> {
                     val songId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val playCountSongs = repository.playCountSongs()
+                    val correctIndex = playCountSongs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error                    
                     MediaItemsWithStartPosition(
                         playCountSongs.map { it.toPlayableMediaItem() },
-                        playCountSongs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
+                
                 MediaIDs.RECENT_SONGS -> {
                     val songId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val historySongs = repository.historySongs()
+                    val correctIndex = historySongs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+
                     MediaItemsWithStartPosition(
                         historySongs.map { it.toPlayableMediaItem() },
-                        historySongs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
@@ -181,13 +213,16 @@ class LibraryProvider(private val repository: Repository) {
                 MediaIDs.FAVORITES -> {
                     val songId = path.getOrNull(1)?.toLongOrNull() ?: return null
                     val favoriteSongs = repository.favoriteSongs()
+                    val correctIndex = favoriteSongs.indexOfFirst { it.id == songId }
+                    if (correctIndex < 0)
+                        return null // Bad user input, don't send the first song but a true error
+
                     MediaItemsWithStartPosition(
                         favoriteSongs.map { it.toPlayableMediaItem() },
-                        favoriteSongs.indexOfFirst { it.id == songId }.coerceAtLeast(0),
+                        correctIndex,
                         C.TIME_UNSET
                     )
                 }
-
                 else -> null
             }
         } catch (e: Exception) {


### PR DESCRIPTION
## Description
When using my head unit (which in turns uses Bluetooth AVRCP1.5 protocol to fetch items to play via `getFolderItems`), BoomingMusic returned a virtual filesystem with all my tracks (good). 
However, if I select a track in the list, only the first or the second track plays (not good).

By looking at the code (and my Bluetooth player log), I think I've found the issue. BoomingMusic set "SONGS:parent:2124" in its UID, but when I click on an item to play it, it's searching for "SONGS:2124" which, obviously doesn't match.
Then happen the second bug, since `indexOfFirst` doesn't find it, it results -1 which is `coerceAtLeast(0)` so it falls back to the first song.

This PR fixes the issue by extracting the parentId and generating the same UID as what was sent to AVRCP's session (so indexOfFirst matches) and also removing the coerce part (it returns null if it doesn't find the item, instead of returning the wrong one). This should also fix a malformed user request that would have worked previously.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no functional changes)
- [ ] Performance optimization
- [ ] Documentation update

## AI Agent Usage Disclosure
- [ ] **I used an AI agent (e.g., Gemini, Claude, ChatGPT) to assist with this code.**
  - *If checked, please consider specifying the agent used and which parts of the code were generated/modified by it:*
- [X] I did NOT use an AI agent for this contribution.

## Checklist
- [X] My code follows the project's coding style and guidelines.
- [X] I have verified that my changes do not compromise user experience or performance

## Summary by Sourcery

Fix AVRCP track selection so requested songs resolve to the correct item and invalid requests do not play an unintended track.

Bug Fixes:
- Fix playing selected tracks from AVRCP library lists by preserving the correct parent context in generated media identifiers.
- Return an error for invalid track requests instead of silently falling back to the first song.