### PR TITLE
Fix library root gate keeper

### DIFF
--- a/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
@@ -407,7 +407,7 @@ class PlaybackService :
             if (sessionId == myPackageName) {
                 return mediaSession
             }
-        } else if (packageValidator.isKnownCaller(controllerPackageName, controllerInfo.uid)) {
+        } else if (packageValidator.isAllowedCaller(controllerPackageName, controllerInfo.uid)) {
             return mediaSession
         }
         return null
@@ -465,7 +465,7 @@ class PlaybackService :
         browser: MediaSession.ControllerInfo,
         params: LibraryParams?
     ): ListenableFuture<LibraryResult<MediaItem>> {
-        val isKnownCaller = packageValidator.isKnownCaller(browser.packageName, browser.uid)
+        val isKnownCaller = packageValidator.isAllowedCaller(browser.packageName, browser.uid)
         val outExtras = Bundle().apply {
             putBoolean(MediaConstants.BROWSER_SERVICE_EXTRAS_KEY_SEARCH_SUPPORTED, isKnownCaller)
         }

--- a/app/src/main/java/com/mardous/booming/ui/screen/settings/PreferencesScreenFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/settings/PreferencesScreenFragment.kt
@@ -150,8 +150,10 @@ class AdvancedPreferencesFragment : PreferenceScreenFragment() {
                 .map { it.title }
                 .toTypedArray()
         }
+        addPreferencesFromResource(R.xml.preferences_screen_gatekeeper)
     }
 }
+
 
 open class PreferenceScreenFragment : PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {

--- a/app/src/main/java/com/mardous/booming/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/settings/SettingsScreen.kt
@@ -31,5 +31,5 @@ enum class SettingsScreen(@LayoutRes val layoutRes: Int, @IdRes val navAction: I
     Playback(R.xml.preferences_screen_playback, R.id.action_to_playbackPreferences),
     Library(R.xml.preferences_screen_library, R.id.action_to_libraryPreferences),
     Network(R.xml.preferences_screen_network, R.id.action_to_networkPreferences),
-    Advanced(R.xml.preferences_screen_advanced, R.id.action_to_advancedPreferences);
+    Advanced(R.xml.preferences_screen_advanced, R.id.action_to_advancedPreferences),
 }

--- a/app/src/main/java/com/mardous/booming/util/PackageValidator.kt
+++ b/app/src/main/java/com/mardous/booming/util/PackageValidator.kt
@@ -67,6 +67,17 @@ internal class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
     }
 
     /**
+     * The gate used by the browsing/session callbacks. Behaves like [isKnownCaller], unless
+     * caller enforcement is turned OFF in Developer Settings, in which case every caller is 
+     * allowed to browse the library. This lets unofficial Android-Auto clients (which are not
+     * in [allowed_media_browser_callers]) browse during development without weakening the
+     * check for users who explicitly opt back in.
+     */
+    fun isAllowedCaller(callingPackage: String, callingUid: Int): Boolean =
+        if (!Preferences.enforceKnownCallers) true
+        else isKnownCaller(callingPackage, callingUid)
+
+    /**
      * Checks whether the caller attempting to connect to a [MediaBrowserServiceCompat] is known.
      * See [MusicService.onGetRoot] for where this is utilized.
      *
@@ -94,9 +105,14 @@ internal class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
          * reassigned.)
          */
 
-        // Build the caller info for the rest of the checks here.
+        // Build the caller info for the rest of the checks here. A caller whose package can't be
+        // resolved (e.g. a legacy MediaBrowser connecting under a placeholder package that isn't
+        // installed) is simply treated as unknown rather than crashing the service.
         val callerPackageInfo = buildCallerInfo(callingPackage)
-            ?: throw IllegalStateException("Caller wasn't found in the system?")
+        if (callerPackageInfo == null) {
+            callerChecked[callingPackage] = Pair(callingUid, false)
+            return false
+        }
 
         // Verify that things aren't ... broken. (This test should always pass.)
         if (callerPackageInfo.uid != callingUid) {
@@ -196,10 +212,14 @@ internal class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
     @Suppress("DEPRECATION")
     @SuppressLint("PackageManagerGetSignatures")
     private fun getPackageInfo(callingPackage: String): PackageInfo? =
-        packageManager.getPackageInfo(
-            callingPackage,
-            PackageManager.GET_SIGNATURES or PackageManager.GET_PERMISSIONS
-        )
+        try {
+            packageManager.getPackageInfo(
+                callingPackage,
+                PackageManager.GET_SIGNATURES or PackageManager.GET_PERMISSIONS
+            )
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
 
     /**
      * Gets the signature of a given package's [PackageInfo].

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -74,6 +74,15 @@ object Preferences : KoinComponent {
         get() = preferences.getStringSet("requested_permissions", emptySet()).orEmpty()
         set(value) = preferences.edit { putStringSet("requested_permissions", value) }
 
+    /**
+     * When ON (the default), only callers in `allowed_media_browser_callers` may browse the media library
+     * (Android Auto, Assistant, etc.). When OFF, any caller is allowed - needed
+     * for unofficial Android-Auto clients or other free media client. See [PackageValidator.isAllowedCaller].
+     */
+    var enforceKnownCallers: Boolean
+        get() = preferences.getBoolean(ENFORCE_KNOWN_CALLERS, true)
+        set(value) = preferences.edit { putBoolean(ENFORCE_KNOWN_CALLERS, value) }
+
     fun getGeneralTheme(isBlackMode: Boolean): String {
         return if (isBlackMode) {
             GeneralTheme.BLACK
@@ -618,6 +627,7 @@ const val ARTIST_MINIMUM_SONGS = "artist_minimum_songs"
 const val ALBUM_MINIMUM_SONGS = "album_minimum_songs"
 const val MINIMUM_SONG_DURATION = "minimum_song_duration"
 const val ENABLE_ROTATION_LOCK = "enable_rotation_lock"
+const val ENFORCE_KNOWN_CALLERS = "enforce_known_callers"
 const val STOP_WHEN_CLOSED_FROM_RECENTS = "stop_when_closed_from_recents"
 const val LANGUAGE_NAME = "language_name"
 const val AUTO_LANGUAGE = "auto"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -653,6 +653,8 @@
     <string name="network_summary">Manage internet features such as Last.fm integration, lyrics providers, and metadata downloads.</string>
     <string name="advanced_title">Advanced</string>
     <string name="advanced_summary">In-app language and other settings for advanced users.</string>
+    <string name="enforce_known_callers_title">Enforce Known Callers to browse the library</string>
+    <string name="enforce_known_callers_summary">When on, only trusted apps (Android Auto, Assistant, etc.) may browse the media library. Turn off to allow any app to browse it — like open source Android Auto clients.</string>
     <string name="about_title">About</string>
     <string name="about_summary">Booming Music %s, touch for more info.</string>
 

--- a/app/src/main/res/xml/preferences_screen_gatekeeper.xml
+++ b/app/src/main/res/xml/preferences_screen_gatekeeper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <SwitchPreferenceCompat
+        app:icon="@drawable/ic_bug_report_24dp"
+        app:title="@string/enforce_known_callers_title"
+        app:summary="@string/enforce_known_callers_summary"
+        app:defaultValue="true"
+        app:layout="@layout/list_item_view"
+        app:widgetLayout="@layout/preference_switch"
+        app:key="enforce_known_callers"/>
+
+</PreferenceScreen>


### PR DESCRIPTION
## Description
Fix #550 (see issue for reason). This adds a preference in Advanced screen that allow disabling gatekeeping for the library root browser. 

As a side quest, I've fixed a crash when buildCallerInfo returned null (returns false from isKnownCaller instead of crashing the service 2 lines later) and handle getPackageInfo's throwing NameNotFoundException by returning null instead of bring the whole service to crash.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no functional changes)
- [ ] Performance optimization
- [ ] Documentation update

## AI Agent Usage Disclosure
- [ ] **I used an AI agent (e.g., Gemini, Claude, ChatGPT) to assist with this code.**
  - *If checked, please consider specifying the agent used and which parts of the code were generated/modified by it:*
- [X] I did NOT use an AI agent for this contribution.

## Checklist
- [X] My code follows the project's coding style and guidelines.
- [X] I have verified that my changes do not compromise user experience or performance

## Summary by Sourcery

Allow users to control library caller gatekeeping while making invalid caller handling fail safely.

New Features:
- Add an Advanced setting to disable known-caller enforcement for library browsing and session access.

Bug Fixes:
- Prevent unknown or unresolvable media callers from crashing the playback service by treating them as unauthorized.