### PR TITLE
Fix media browser arbitration

### DIFF
--- a/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
@@ -413,6 +413,99 @@ class PlaybackService :
         return null
     }
 
+    // ---- Playback ownership arbitration (Bluetooth vs Android Auto) -------------------------------
+    // One transport "owns" active playback so a second transport's automatic behaviour can't fight
+    // it: a Bluetooth connect/disconnect resume-or-pause won't disrupt an Android-Auto session, and
+    // vice-versa. LOCAL (this app's own UI) is a pass-through override — it always applies and never
+    // changes ownership. Only BLUETOOTH / ANDROID_AUTO are ever stored as owner.
+    private enum class PlaybackSource { BLUETOOTH, ANDROID_AUTO, LOCAL }
+
+    @Volatile private var playbackOwner: PlaybackSource? = null
+    // Re-armed when all AA controllers disconnect, so 'resume on connect' fires once per AA session.
+    @Volatile private var aaAutoResumeArmed = true
+
+    private fun sourceOf(controller: MediaSession.ControllerInfo): PlaybackSource = when {
+        controller.uid == Process.myUid() -> PlaybackSource.LOCAL
+        // The Bluetooth stack drives playback over AVRCP as this controller; keep it distinct from
+        // an Android-Auto client so the two arbitrate against each other (and BT connect/disconnect
+        // auto-actions apply in Bluetooth-only sessions).
+        controller.packageName == "com.android.bluetooth" -> PlaybackSource.BLUETOOTH
+        else -> PlaybackSource.ANDROID_AUTO
+    }
+
+    private fun releaseOwnership() {
+        playbackOwner = null
+    }
+
+    /** Rule 2: tell a rejected controller why. For a legacy client this surfaces as a PlaybackState
+     *  error the client can display. */
+    private fun notifyRejected(controller: MediaSession.ControllerInfo) {
+        runCatching {
+            mediaSession?.sendError(
+                controller,
+                SessionError(SessionError.ERROR_INVALID_STATE, getString(R.string.playback_owned_by_other))
+            )
+        }
+    }
+
+    override fun onPlayerCommandRequest(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        playerCommand: Int
+    ): Int {
+        val src = sourceOf(controller)
+        // LOCAL (this app) is a pass-through override: always allowed, never owns.
+        if (src != PlaybackSource.LOCAL &&
+            (playerCommand == Player.COMMAND_PLAY_PAUSE ||
+                playerCommand == Player.COMMAND_SET_MEDIA_ITEM ||
+                playerCommand == Player.COMMAND_PREPARE)
+        ) {
+            val owner = playbackOwner
+            if (owner != null && owner != src) {
+                notifyRejected(controller)
+                return SessionResult.RESULT_ERROR_PERMISSION_DENIED
+            }
+            // A start command from an unowned session assigns ownership (not a mere pause).
+            val isStart = playerCommand == Player.COMMAND_SET_MEDIA_ITEM ||
+                (playerCommand == Player.COMMAND_PLAY_PAUSE && !player.isPlaying)
+            if (owner == null && isStart) {
+                playbackOwner = src
+            }
+        }
+        return super.onPlayerCommandRequest(session, controller, playerCommand)
+    }
+
+    override fun onPostConnect(session: MediaSession, controller: MediaSession.ControllerInfo) {
+        super.onPostConnect(session, controller)
+        // Rule 5: symmetric with Bluetooth. An AA client connecting while nobody owns playback
+        // auto-resumes if 'resume on connect' is enabled. Debounced so fakeaa's browser+controller
+        // pair only triggers once.
+        if (sourceOf(controller) == PlaybackSource.ANDROID_AUTO &&
+            playbackOwner == null && aaAutoResumeArmed &&
+            !player.isPlaying && Preferences.isResumeOnConnect(true)
+        ) {
+            aaAutoResumeArmed = false
+            playbackOwner = PlaybackSource.ANDROID_AUTO
+            player.play()
+        }
+    }
+
+    override fun onDisconnected(session: MediaSession, controller: MediaSession.ControllerInfo) {
+        if (sourceOf(controller) == PlaybackSource.ANDROID_AUTO) {
+            val aaStillConnected = mediaSession?.connectedControllers.orEmpty()
+                .any { it != controller && sourceOf(it) == PlaybackSource.ANDROID_AUTO }
+            if (!aaStillConnected) {
+                aaAutoResumeArmed = true
+                if (playbackOwner == PlaybackSource.ANDROID_AUTO) {
+                    // Rule 4: the disconnect pref applies to AA just like Bluetooth.
+                    if (Preferences.isPauseOnDisconnect(true)) player.pause()
+                    releaseOwnership()
+                }
+            }
+        }
+        super.onDisconnected(session, controller)
+    }
+
     override fun onConnectAsync(
         session: MediaSession,
         controller: MediaSession.ControllerInfo
@@ -749,6 +842,12 @@ class PlaybackService :
             preferences.getBoolean(CLEAR_QUEUE_ON_COMPLETION, false)) {
             player.exoPlayer.clearMediaItems()
         }
+        // Ownership ends when playback truly stops (queue finished, or stopped while not starting),
+        // so another transport can take over. A pause stays STATE_READY, so the owner is kept.
+        if (playbackState == Player.STATE_ENDED ||
+            (playbackState == Player.STATE_IDLE && !player.playWhenReady)) {
+            releaseOwnership()
+        }
         refreshMediaButtonCustomLayout()
     }
 
@@ -762,6 +861,16 @@ class PlaybackService :
     }
 
     override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+        // While Android Auto owns playback the audio is captured to the car, not the phone's local
+        // output, so a Bluetooth route drop ("becoming noisy") shouldn't pause the cast. ExoPlayer's
+        // own becoming-noisy handler pauses independently of our arbitration, so undo it here.
+        if (!playWhenReady &&
+            reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY &&
+            playbackOwner == PlaybackSource.ANDROID_AUTO
+        ) {
+            player.play()
+            return
+        }
         if (reason == Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM) {
             player.exoPlayer.pauseAtEndOfMediaItems = false
             sleepTimer.consumePendingQuit()
@@ -1263,23 +1372,33 @@ class PlaybackService :
             when (intent?.action) {
                 BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED -> {
                     when (intent.getIntExtra(BluetoothProfile.EXTRA_STATE, -1)) {
-                        BluetoothA2dp.STATE_CONNECTED -> if (Preferences.isResumeOnConnect(true)) {
-                            player.play()
-                        }
-                        BluetoothA2dp.STATE_DISCONNECTED -> if (Preferences.isPauseOnDisconnect(true)) {
-                            player.pause()
-                        }
+                        BluetoothA2dp.STATE_CONNECTED -> onBluetoothConnected()
+                        BluetoothA2dp.STATE_DISCONNECTED -> onBluetoothDisconnected()
                     }
                 }
                 BluetoothDevice.ACTION_ACL_CONNECTED ->
-                    if (context.isBluetoothA2dpConnected() && Preferences.isResumeOnConnect(true)) {
-                        player.play()
-                    }
+                    if (context.isBluetoothA2dpConnected()) onBluetoothConnected()
                 BluetoothDevice.ACTION_ACL_DISCONNECTED ->
-                    if (context.isBluetoothA2dpDisconnected() && Preferences.isPauseOnDisconnect(true)) {
-                        player.pause()
-                    }
+                    if (context.isBluetoothA2dpDisconnected()) onBluetoothDisconnected()
             }
+        }
+    }
+
+    // Bluetooth auto-resume/pause, ownership-aware: suppressed only while Android Auto owns playback
+    // (so a flapping BT link to the car can't pause an AA session). Otherwise stock behaviour.
+    private fun onBluetoothConnected() {
+        if (playbackOwner == PlaybackSource.ANDROID_AUTO) return
+        if (Preferences.isResumeOnConnect(true)) {
+            if (playbackOwner == null) playbackOwner = PlaybackSource.BLUETOOTH
+            player.play()
+        }
+    }
+
+    private fun onBluetoothDisconnected() {
+        if (playbackOwner == PlaybackSource.ANDROID_AUTO) return
+        if (Preferences.isPauseOnDisconnect(true)) {
+            player.pause()
+            if (playbackOwner == PlaybackSource.BLUETOOTH) releaseOwnership()
         }
     }
 

--- a/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
+++ b/app/src/main/java/com/mardous/booming/playback/PlaybackService.kt
@@ -407,7 +407,7 @@ class PlaybackService :
             if (sessionId == myPackageName) {
                 return mediaSession
             }
-        } else if (packageValidator.isKnownCaller(controllerPackageName, controllerInfo.uid)) {
+        } else if (packageValidator.isAllowedCaller(controllerPackageName, controllerInfo.uid)) {
             return mediaSession
         }
         return null
@@ -465,7 +465,7 @@ class PlaybackService :
         browser: MediaSession.ControllerInfo,
         params: LibraryParams?
     ): ListenableFuture<LibraryResult<MediaItem>> {
-        val isKnownCaller = packageValidator.isKnownCaller(browser.packageName, browser.uid)
+        val isKnownCaller = packageValidator.isAllowedCaller(browser.packageName, browser.uid)
         val outExtras = Bundle().apply {
             putBoolean(MediaConstants.BROWSER_SERVICE_EXTRAS_KEY_SEARCH_SUPPORTED, isKnownCaller)
         }
@@ -634,7 +634,10 @@ class PlaybackService :
     private fun <T : Any> MediaSession.denyUntrusted(
         controller: MediaSession.ControllerInfo
     ): ListenableFuture<LibraryResult<T>>? =
-        if (isTrustedController(controller)) null
+        // Same gate the library root uses: when caller enforcement is off (Advanced Settings),
+        // any controller may browse - otherwise browsing the children would still be
+        // denied even though the root was allowed, giving an empty library.
+        if (!Preferences.enforceKnownCallers || isTrustedController(controller)) null
         else Futures.immediateFuture(LibraryResult.ofError<T>(SessionError.ERROR_PERMISSION_DENIED))
 
     override fun onCustomCommand(

--- a/app/src/main/java/com/mardous/booming/ui/screen/settings/PreferencesScreenFragment.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/settings/PreferencesScreenFragment.kt
@@ -148,8 +148,10 @@ class AdvancedPreferencesFragment : PreferenceScreenFragment() {
                 .map { it.title }
                 .toTypedArray()
         }
+        addPreferencesFromResource(R.xml.preferences_screen_gatekeeper)
     }
 }
+
 
 open class PreferenceScreenFragment : PreferenceFragmentCompat(),
     SharedPreferences.OnSharedPreferenceChangeListener {

--- a/app/src/main/java/com/mardous/booming/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/settings/SettingsScreen.kt
@@ -31,5 +31,5 @@ enum class SettingsScreen(@LayoutRes val layoutRes: Int, @IdRes val navAction: I
     Playback(R.xml.preferences_screen_playback, R.id.action_to_playbackPreferences),
     Library(R.xml.preferences_screen_library, R.id.action_to_libraryPreferences),
     Network(R.xml.preferences_screen_network, R.id.action_to_networkPreferences),
-    Advanced(R.xml.preferences_screen_advanced, R.id.action_to_advancedPreferences);
+    Advanced(R.xml.preferences_screen_advanced, R.id.action_to_advancedPreferences),
 }

--- a/app/src/main/java/com/mardous/booming/util/PackageValidator.kt
+++ b/app/src/main/java/com/mardous/booming/util/PackageValidator.kt
@@ -67,6 +67,17 @@ internal class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
     }
 
     /**
+     * The gate used by the browsing/session callbacks. Behaves like [isKnownCaller], unless
+     * caller enforcement is turned OFF in Developer Settings, in which case every caller is 
+     * allowed to browse the library. This lets unofficial Android-Auto clients (which are not
+     * in [allowed_media_browser_callers]) browse during development without weakening the
+     * check for users who explicitly opt back in.
+     */
+    fun isAllowedCaller(callingPackage: String, callingUid: Int): Boolean =
+        if (!Preferences.enforceKnownCallers) true
+        else isKnownCaller(callingPackage, callingUid)
+
+    /**
      * Checks whether the caller attempting to connect to a [MediaBrowserServiceCompat] is known.
      * See [MusicService.onGetRoot] for where this is utilized.
      *
@@ -94,9 +105,14 @@ internal class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
          * reassigned.)
          */
 
-        // Build the caller info for the rest of the checks here.
+        // Build the caller info for the rest of the checks here. A caller whose package can't be
+        // resolved (e.g. a legacy MediaBrowser connecting under a placeholder package that isn't
+        // installed) is simply treated as unknown rather than crashing the service.
         val callerPackageInfo = buildCallerInfo(callingPackage)
-            ?: throw IllegalStateException("Caller wasn't found in the system?")
+        if (callerPackageInfo == null) {
+            callerChecked[callingPackage] = Pair(callingUid, false)
+            return false
+        }
 
         // Verify that things aren't ... broken. (This test should always pass.)
         if (callerPackageInfo.uid != callingUid) {
@@ -196,10 +212,14 @@ internal class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
     @Suppress("DEPRECATION")
     @SuppressLint("PackageManagerGetSignatures")
     private fun getPackageInfo(callingPackage: String): PackageInfo? =
-        packageManager.getPackageInfo(
-            callingPackage,
-            PackageManager.GET_SIGNATURES or PackageManager.GET_PERMISSIONS
-        )
+        try {
+            packageManager.getPackageInfo(
+                callingPackage,
+                PackageManager.GET_SIGNATURES or PackageManager.GET_PERMISSIONS
+            )
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
 
     /**
      * Gets the signature of a given package's [PackageInfo].

--- a/app/src/main/java/com/mardous/booming/util/Preferences.kt
+++ b/app/src/main/java/com/mardous/booming/util/Preferences.kt
@@ -74,6 +74,15 @@ object Preferences : KoinComponent {
         get() = preferences.getStringSet("requested_permissions", emptySet()).orEmpty()
         set(value) = preferences.edit { putStringSet("requested_permissions", value) }
 
+    /**
+     * When ON (the default), only callers in `allowed_media_browser_callers` may browse the media library
+     * (Android Auto, Assistant, etc.). When OFF, any caller is allowed - needed
+     * for unofficial Android-Auto clients or other free media client. See [PackageValidator.isAllowedCaller].
+     */
+    var enforceKnownCallers: Boolean
+        get() = preferences.getBoolean(ENFORCE_KNOWN_CALLERS, true)
+        set(value) = preferences.edit { putBoolean(ENFORCE_KNOWN_CALLERS, value) }
+
     fun getGeneralTheme(isBlackMode: Boolean): String {
         return if (isBlackMode) {
             GeneralTheme.BLACK
@@ -618,6 +627,7 @@ const val ARTIST_MINIMUM_SONGS = "artist_minimum_songs"
 const val ALBUM_MINIMUM_SONGS = "album_minimum_songs"
 const val MINIMUM_SONG_DURATION = "minimum_song_duration"
 const val ENABLE_ROTATION_LOCK = "enable_rotation_lock"
+const val ENFORCE_KNOWN_CALLERS = "enforce_known_callers"
 const val STOP_WHEN_CLOSED_FROM_RECENTS = "stop_when_closed_from_recents"
 const val LANGUAGE_NAME = "language_name"
 const val AUTO_LANGUAGE = "auto"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,6 +677,8 @@
     <string name="network_summary">Manage internet features such as Last.fm integration, lyrics providers, and metadata downloads.</string>
     <string name="advanced_title">Advanced</string>
     <string name="advanced_summary">In-app language and other settings for advanced users.</string>
+    <string name="enforce_known_callers_title">Enforce Known Callers to browse the library</string>
+    <string name="enforce_known_callers_summary">When on, only trusted apps (Android Auto, Assistant, etc.) may browse the media library. Turn off to allow any app to browse it — like open source Android Auto clients.</string>
     <string name="about_title">About</string>
     <string name="about_summary">Booming Music %s, touch for more info.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,6 +677,7 @@
     <string name="network_summary">Manage internet features such as Last.fm integration, lyrics providers, and metadata downloads.</string>
     <string name="advanced_title">Advanced</string>
     <string name="advanced_summary">In-app language and other settings for advanced users.</string>
+    <string name="playback_owned_by_other">Playback is controlled by another connection</string>
     <string name="enforce_known_callers_title">Enforce Known Callers to browse the library</string>
     <string name="enforce_known_callers_summary">When on, only trusted apps (Android Auto, Assistant, etc.) may browse the media library. Turn off to allow any app to browse it — like open source Android Auto clients.</string>
     <string name="about_title">About</string>

--- a/app/src/main/res/xml/preferences_screen_gatekeeper.xml
+++ b/app/src/main/res/xml/preferences_screen_gatekeeper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <SwitchPreferenceCompat
+        app:icon="@drawable/ic_bug_report_24dp"
+        app:title="@string/enforce_known_callers_title"
+        app:summary="@string/enforce_known_callers_summary"
+        app:defaultValue="true"
+        app:layout="@layout/list_item_view"
+        app:widgetLayout="@layout/preference_switch"
+        app:key="enforce_known_callers"/>
+
+</PreferenceScreen>


### PR DESCRIPTION
## Description
This follow #558 and is required for having a working arbitration between 2 simultaneous media browser. This happens if you have Bluetooth connected and you plug Android Auto to your car. In that case, when AA's user starts playing a song, it disables BT. But once BT disconnect, it stops the current play. From the user perspective, clicking play triggers play then immediately, pause. The user has to either disconnect BT because using AA or unlock her phone to click play here.

So, in order to avoid this issue, arbitration is added, that's tracking who's the last controller and in case of conflict, only allow the last controller to change the media session state.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no functional changes)
- [ ] Performance optimization
- [ ] Documentation update

## AI Agent Usage Disclosure
- [ ] **I used an AI agent (e.g., Gemini, Claude, ChatGPT) to assist with this code.**
  - *If checked, please consider specifying the agent used and which parts of the code were generated/modified by it:*
- [X] I did NOT use an AI agent for this contribution.

## Checklist
- [X] My code follows the project's coding style and guidelines.
- [X] I have verified that my changes do not compromise user experience or performance

## Screenshots / Videos (if applicable)
Add any visual evidence of the changes here.

## Summary by Sourcery

Prevent simultaneous Bluetooth and Android Auto media controllers from conflicting over playback state.

New Features:
- Add playback ownership arbitration between Bluetooth and Android Auto media controllers.
- Add an Advanced Settings option to allow unrestricted media-library browsing for unofficial clients.

Bug Fixes:
- Prevent Bluetooth connection changes and competing media controllers from interrupting playback owned by another transport.
- Handle missing caller packages safely instead of failing during media-browser validation.

Enhancements:
- Apply caller-allowance configuration consistently across media-session and library browsing access.
- Support Android Auto resume and pause-on-disconnect behavior within playback ownership rules.