### PR TITLE
Legacy pl-SP migration, continuation of PR#548

### DIFF
--- a/app/src/main/java/com/mardous/booming/extensions/LocaleExt.kt
+++ b/app/src/main/java/com/mardous/booming/extensions/LocaleExt.kt
@@ -17,7 +17,8 @@ private val displayTagOverrides = mapOf(
 private val displayNameOverrides = mapOf(
     "bqi" to "لۊری بختیاری",
     "zh-Hans" to "中文（简体）",
-    "zh-Hant" to "中文（繁體）"
+    "zh-Hant" to "中文（繁體）",
+    "szl" to "Ślōnski"
 )
 
 private const val REGIONAL_INDICATOR_A = 0x1F1E6

--- a/app/src/main/java/com/mardous/booming/ui/screen/onboard/OnboardActivity.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/onboard/OnboardActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.preference.PreferenceManager
@@ -35,6 +36,13 @@ import com.mardous.booming.util.GENERAL_THEME
 import com.mardous.booming.util.GeneralTheme
 import com.mardous.booming.util.MATERIAL_YOU
 import com.mardous.booming.util.Preferences
+import com.mardous.booming.util.LANGUAGE_NAME
+import android.content.res.Resources
+import android.content.SharedPreferences
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.edit
+import androidx.core.os.LocaleListCompat
+import java.util.Locale
 
 /**
  * @author Christians M. A. (mardous)
@@ -48,6 +56,9 @@ class OnboardActivity : AbsBaseActivity() {
 
         setContent {
             val prefs = remember { PreferenceManager.getDefaultSharedPreferences(this) }
+
+            LaunchedEffect(Unit) {
+                redirectSilesian(prefs)}
 
             val generalTheme by prefs.observeKeyAsState(GENERAL_THEME, GeneralTheme.AUTO)
             val materialYou by prefs.observeKeyAsState(MATERIAL_YOU, hasS())
@@ -83,5 +94,15 @@ class OnboardActivity : AbsBaseActivity() {
                 )
             }
         }
+    }
+	
+private fun redirectSilesian(prefs: SharedPreferences) {
+    val isAuto = AppCompatDelegate.getApplicationLocales().isEmpty
+    if (!isAuto) return
+    val systemLocale: Locale? = Resources.getSystem().configuration.locales[0]
+    if (systemLocale?.toLanguageTag() == "pl-SP") {
+        prefs.edit { putString(LANGUAGE_NAME, "szl") }
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("szl"))
+      }
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -185,6 +185,7 @@
         <item>no</item>
         <item>fa</item>
         <item>pl</item>
+		<item>szl</item>
         <item>pt-PT</item>
         <item>pt-BR</item>
         <item>ro</item>


### PR DESCRIPTION
## Description
Pretty much the same thing in a fresh coat of paint

> ## Description
> This pull request makes Silesian selectable via the language picker by adding it to arrays and adding its name.
> 
> It also adds a check on onboarding for when a user has pl-SP set and, if they do, sets Silesian (szl) instead.
> 
> > Samsung devices supported Silesian as an independent locale which was pl-SP, added before android officially added Silesian (szl)
> 
> ## Type of Change
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Refactor (code improvement with no functional changes)
> - [ ] Performance optimization
> - [ ] Documentation update
> 
> ## AI Agent Usage Disclosure
> - [x] **I used an AI agent (Claude) to assist with this code.**
>   - *For reviewing/debugging Samsung's Remote Test Lab logs*
> - [ ] I did NOT use an AI agent for this contribution.
> 
> ## Checklist
> - [x] My code follows the project's coding style and guidelines.
> - [x] I have verified that my changes do not compromise user experience or performance
> 
> ## Screenshots / Videos (if applicable)
> <img height="400" alt="Screenshot_20260829-030818" src="https://github.com/user-attachments/assets/733da5e7-9cc7-4629-a0a7-228c16c44dfc" /><img height="400" alt="Zrzut ekranu 2026-08-29 011928" src="https://github.com/user-attachments/assets/502d309a-8d13-4d08-84b0-f6a7305454bb" />

## Summary by Sourcery

Support Silesian language selection and migrate users from the legacy pl-SP locale.

New Features:
- Add Silesian (szl) to the selectable application languages with its localized display name.

Bug Fixes:
- Migrate legacy Samsung pl-SP language settings to Silesian and handle pl-SP system locales during startup.