### PR TITLE
feat(lyrics): add transparent multi-provider search progress

### DIFF
--- a/app/src/main/java/com/mardous/booming/data/remote/lyrics/LyricsDownloadService.kt
+++ b/app/src/main/java/com/mardous/booming/data/remote/lyrics/LyricsDownloadService.kt
@@ -28,7 +28,10 @@ import com.mardous.booming.data.remote.lyrics.api.lyrically.LyricallyApi
 import com.mardous.booming.extensions.media.albumArtistName
 import com.mardous.booming.extensions.media.extractMainArtistName
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import java.io.IOException
+import java.net.SocketTimeoutException
+import kotlinx.coroutines.CancellationException
 
 class LyricsProviderParams(
     val providers: List<LyricsProvider> = LyricsProvider.AvailableProviders,
@@ -50,36 +53,106 @@ class LyricsDownloadService(client: HttpClient) {
         title: String = song.title,
         artist: String = song.albumArtistName(),
         providerParams: LyricsProviderParams = LyricsProviderParams()
-    ): RawLyrics.Remote {
+    ): RawLyrics.Remote = searchLyrics(
+        song = song,
+        title = title,
+        artist = artist,
+        providerParams = providerParams,
+        continueAfterComplete = false
+    ).lyrics
+
+    suspend fun searchLyrics(
+        song: Song,
+        title: String = song.title,
+        artist: String = song.albumArtistName(),
+        providerParams: LyricsProviderParams = LyricsProviderParams(),
+        continueAfterComplete: Boolean = true,
+        onProviderResult: suspend (LyricsProviderSearchResult) -> Unit = {}
+    ): LyricsSearchResult {
         check(providerParams.providers.isNotEmpty()) { "No providers configured" }
 
         var result = RawLyrics.Remote()
-        if (song == Song.emptySong || !NetworkFeature.isOnline(ignoreWifiSetting = providerParams.ignoreWifiSetting))
-            return result
+        val providers = providerParams.providers.filter { provider ->
+            provider.isAvailableForCurrentPolicy &&
+                (provider.isEnabled || providerParams.ignoreProviderSetting)
+        }
+        val providerResults = providers.associateWith { provider ->
+            LyricsProviderSearchResult(provider, LyricsProviderSearchStatus.Waiting)
+        }.toMutableMap()
+
+        if (song == Song.emptySong ||
+            !NetworkFeature.isOnline(ignoreWifiSetting = providerParams.ignoreWifiSetting)) {
+            providers.forEach { provider ->
+                val failedResult = LyricsProviderSearchResult(
+                    provider = provider,
+                    status = LyricsProviderSearchStatus.Failed
+                )
+                providerResults[provider] = failedResult
+                onProviderResult(failedResult)
+            }
+            return LyricsSearchResult(result, providerResults.values.toList())
+        }
 
         try {
             val cleanedTitle = cleanTitle(title)
             val cleanedArtist = artist.extractMainArtistName()
-            for (provider in providerParams.providers) {
-                if (!provider.isAvailableForCurrentPolicy ||
-                    (!provider.isEnabled && !providerParams.ignoreProviderSetting)) continue
-
+            for (provider in providers) {
                 val api = apiByProvider.getValue(provider)
-                val apiResult = runCatching { api.downloadLyrics(song, cleanedTitle, cleanedArtist) }
-                if (apiResult.isFailure) {
-                    Log.e(TAG, "Error during lyrics request", apiResult.exceptionOrNull())
+                val searchingResult = LyricsProviderSearchResult(
+                    provider = provider,
+                    status = LyricsProviderSearchStatus.Searching
+                )
+                providerResults[provider] = searchingResult
+                onProviderResult(searchingResult)
+
+                val providerResult = try {
+                    val response = api.downloadLyrics(song, cleanedTitle, cleanedArtist)
+                    if (response?.let { it.hasPlain || it.hasSynced } == true) {
+                        result = result.accept(response)
+                        LyricsProviderSearchResult(
+                            provider = provider,
+                            status = LyricsProviderSearchStatus.Found,
+                            lyrics = response
+                        )
+                    } else {
+                        LyricsProviderSearchResult(
+                            provider = provider,
+                            status = LyricsProviderSearchStatus.NoMatch
+                        )
+                    }
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: HttpRequestTimeoutException) {
+                    Log.w(TAG, "Lyrics request timed out for ${provider.displayName}", error)
+                    LyricsProviderSearchResult(
+                        provider = provider,
+                        status = LyricsProviderSearchStatus.TimedOut
+                    )
+                } catch (error: SocketTimeoutException) {
+                    Log.w(TAG, "Lyrics request timed out for ${provider.displayName}", error)
+                    LyricsProviderSearchResult(
+                        provider = provider,
+                        status = LyricsProviderSearchStatus.TimedOut
+                    )
+                } catch (error: Exception) {
+                    Log.e(TAG, "Error during lyrics request for ${provider.displayName}", error)
+                    LyricsProviderSearchResult(
+                        provider = provider,
+                        status = LyricsProviderSearchStatus.Failed
+                    )
                 }
 
-                val response = apiResult.getOrNull() ?: continue
-
-                result = result.accept(response)
-                if (result.hasBoth) break
+                providerResults[provider] = providerResult
+                onProviderResult(providerResult)
+                if (!continueAfterComplete && result.hasBoth) break
             }
+        } catch (error: CancellationException) {
+            throw error
         } catch (e: Exception) {
             Log.e(TAG, "Lyrics download failed with error:", e)
         }
 
-        return result
+        return LyricsSearchResult(result, providerResults.values.toList())
     }
 
     /**

--- a/app/src/main/java/com/mardous/booming/data/remote/lyrics/LyricsSearchResult.kt
+++ b/app/src/main/java/com/mardous/booming/data/remote/lyrics/LyricsSearchResult.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Christians Martínez Alvarado
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.mardous.booming.data.remote.lyrics
+
+import com.mardous.booming.data.model.lyrics.RawLyrics
+import com.mardous.booming.data.remote.lyrics.api.LyricsProvider
+
+enum class LyricsProviderSearchStatus {
+    Waiting,
+    Searching,
+    Found,
+    NoMatch,
+    Failed,
+    TimedOut
+}
+
+data class LyricsProviderSearchResult(
+    val provider: LyricsProvider,
+    val status: LyricsProviderSearchStatus,
+    val lyrics: RawLyrics.Remote? = null
+) {
+    val isTerminal: Boolean
+        get() = when (status) {
+            LyricsProviderSearchStatus.Waiting,
+            LyricsProviderSearchStatus.Searching -> false
+            else -> true
+        }
+
+    val isUsable: Boolean
+        get() = status == LyricsProviderSearchStatus.Found &&
+            lyrics?.let { it.hasPlain || it.hasSynced } == true
+
+    val qualityScore: Int
+        get() = when {
+            lyrics?.hasBoth == true -> 3
+            lyrics?.hasSynced == true -> 2
+            lyrics?.hasPlain == true -> 1
+            else -> 0
+        }
+}
+
+data class LyricsSearchResult(
+    val lyrics: RawLyrics.Remote,
+    val providerResults: List<LyricsProviderSearchResult>
+)

--- a/app/src/main/java/com/mardous/booming/data/remote/lyrics/api/lrclib/LrcLibApi.kt
+++ b/app/src/main/java/com/mardous/booming/data/remote/lyrics/api/lrclib/LrcLibApi.kt
@@ -33,12 +33,15 @@ class LrcLibApi(private val client: HttpClient) : LyricsApi {
         } else {
             val songDurationInSeconds = (song.duration / 1000).toDouble()
             var matchingLyrics = lyrics.firstOrNull {
-                val maxValue = maxOf(songDurationInSeconds, it.durationInSeconds)
-                val minValue = minOf(songDurationInSeconds, it.durationInSeconds)
+                val resultDuration = it.durationInSeconds ?: return@firstOrNull false
+                val maxValue = maxOf(songDurationInSeconds, resultDuration)
+                val minValue = minOf(songDurationInSeconds, resultDuration)
                 ((maxValue - minValue) < 2)
             }
             if (matchingLyrics == null) {
-                matchingLyrics = lyrics.first { !it.plainLyrics.isNullOrEmpty() }
+                matchingLyrics = lyrics.firstOrNull {
+                    !it.plainLyrics.isNullOrEmpty() || !it.syncedLyrics.isNullOrEmpty()
+                } ?: return null
             }
             return RawLyrics.Remote(
                 plain = RawLyrics.Remote.Content(provider.displayName, matchingLyrics.plainLyrics),

--- a/app/src/main/java/com/mardous/booming/data/remote/lyrics/model/LyricsResponse.kt
+++ b/app/src/main/java/com/mardous/booming/data/remote/lyrics/model/LyricsResponse.kt
@@ -13,7 +13,7 @@ data class LRCLibResponse(
     val album: String,
     val instrumental: Boolean,
     @SerialName("duration")
-    val durationInSeconds: Double,
+    val durationInSeconds: Double?,
     val plainLyrics: String?,
     val syncedLyrics: String?
 )

--- a/app/src/main/java/com/mardous/booming/data/repository/LyricsRepository.kt
+++ b/app/src/main/java/com/mardous/booming/data/repository/LyricsRepository.kt
@@ -19,9 +19,12 @@ import com.mardous.booming.data.model.lyrics.RawLyrics
 import com.mardous.booming.data.model.lyrics.SyncedLyrics
 import com.mardous.booming.data.remote.lyrics.LyricsDownloadService
 import com.mardous.booming.data.remote.lyrics.LyricsProviderParams
+import com.mardous.booming.data.remote.lyrics.LyricsProviderSearchResult
+import com.mardous.booming.data.remote.lyrics.LyricsSearchResult
 import com.mardous.booming.extensions.hasR
 import com.mardous.booming.extensions.media.isArtistNameUnknown
 import com.mardous.booming.util.Preferences.requireString
+import kotlinx.coroutines.CancellationException
 import org.mozilla.universalchardet.UniversalDetector
 import java.io.BufferedInputStream
 import java.io.File
@@ -36,6 +39,14 @@ interface LyricsRepository {
     suspend fun embeddedLyrics(song: Song): RawLyrics.Embedded?
     suspend fun storedLyrics(song: Song, allowDownload: Boolean): RawLyrics.Stored?
     suspend fun downloadLyrics(song: Song, searchTitle: String, searchArtist: String, providerParams: LyricsProviderParams): RawLyrics.Remote?
+    suspend fun searchLyrics(
+        song: Song,
+        searchTitle: String,
+        searchArtist: String,
+        providerParams: LyricsProviderParams,
+        onProviderResult: suspend (LyricsProviderSearchResult) -> Unit
+    ): LyricsSearchResult?
+    suspend fun storeDownloadedLyrics(song: Song, lyrics: RawLyrics.Remote): Boolean
 
     suspend fun saveLyrics(
         song: Song,
@@ -198,6 +209,51 @@ class RealLyricsRepository(
             lyricsDownloadService.remoteLyrics(song, searchTitle, searchArtist, providerParams)
         } catch (_: Exception) {
             null
+        }
+    }
+
+    override suspend fun searchLyrics(
+        song: Song,
+        searchTitle: String,
+        searchArtist: String,
+        providerParams: LyricsProviderParams,
+        onProviderResult: suspend (LyricsProviderSearchResult) -> Unit
+    ): LyricsSearchResult? {
+        if (song.id == Song.emptySong.id || searchArtist.isArtistNameUnknown()) {
+            return null
+        }
+        return try {
+            lyricsDownloadService.searchLyrics(
+                song = song,
+                title = searchTitle,
+                artist = searchArtist,
+                providerParams = providerParams,
+                onProviderResult = onProviderResult
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            Log.e(TAG, "Couldn't search lyrics for song ${song.data}", error)
+            null
+        }
+    }
+
+    override suspend fun storeDownloadedLyrics(song: Song, lyrics: RawLyrics.Remote): Boolean {
+        val storedLyrics = lyrics.prepareToStore() ?: return false
+        return try {
+            lyricsDao.insertLyrics(
+                LyricsEntity(
+                    id = song.id,
+                    lyrics = storedLyrics.lyrics,
+                    provider = storedLyrics.provider,
+                    instrumental = storedLyrics.instrumental
+                )
+            )
+            cacheLyrics(song.id, storedLyrics)
+            true
+        } catch (error: Exception) {
+            Log.e(TAG, "Couldn't store downloaded lyrics for song ${song.data}", error)
+            false
         }
     }
 

--- a/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsEditorScreen.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsEditorScreen.kt
@@ -101,7 +101,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mardous.booming.R
 import com.mardous.booming.data.model.Song
-import com.mardous.booming.data.model.lyrics.LyricsMode
 import com.mardous.booming.data.model.lyrics.LyricsSource
 import com.mardous.booming.data.model.lyrics.RawLyrics
 import com.mardous.booming.data.model.network.NetworkFeature
@@ -109,12 +108,10 @@ import com.mardous.booming.data.remote.lyrics.api.LyricsProvider
 import com.mardous.booming.extensions.hasR
 import com.mardous.booming.extensions.media.displayArtistName
 import com.mardous.booming.extensions.media.isArtistNameUnknown
-import com.mardous.booming.extensions.openUrl
 import com.mardous.booming.extensions.showToast
 import com.mardous.booming.extensions.webSearch
 import com.mardous.booming.ui.component.compose.ButtonGroup
 import com.mardous.booming.ui.component.compose.DialogListItemWithCheckBox
-import com.mardous.booming.ui.component.compose.DialogListItemWithRadio
 import com.mardous.booming.ui.component.compose.MediaImage
 import com.mardous.booming.ui.component.compose.ObserveAsEvent
 import com.mardous.booming.ui.component.compose.menu.MenuItem
@@ -215,10 +212,8 @@ fun LyricsEditorScreen(
     }
 
     var showNoConnectionDialog by remember { mutableStateOf(false) }
-    var showManualSearchDialog by remember { mutableStateOf(false) }
     var showLyricsDownloadDialog by remember { mutableStateOf(false) }
     var showLyricsSearchDialog by remember { mutableStateOf(false) }
-    var downloadedLyricsForSelector by rememberSaveable { mutableStateOf<RawLyrics.Remote?>(null) }
 
     ObserveAsEvent(viewModel.saveEvent) { saveResult ->
         val toastMessage = when (saveResult) {
@@ -227,18 +222,6 @@ fun LyricsEditorScreen(
             LyricsEditorResult.Success -> context.getString(R.string.changes_saved_successfully)
         }
         context.showToast(toastMessage)
-    }
-
-    ObserveAsEvent(viewModel.downloadEvent) { downloadedLyrics ->
-        if (downloadedLyrics.hasBoth) {
-            downloadedLyricsForSelector = downloadedLyrics
-        } else if (downloadedLyrics.hasPlain) {
-            textFieldState.setContent(downloadedLyrics.plain?.lyrics)
-        } else if (downloadedLyrics.hasSynced) {
-            textFieldState.setContent(downloadedLyrics.synced?.lyrics)
-        } else {
-            showManualSearchDialog = true
-        }
     }
 
     ObserveAsEvent(viewModel.permissionRequestEvent) { uris ->
@@ -272,47 +255,6 @@ fun LyricsEditorScreen(
         }
     }
 
-    if (downloadedLyricsForSelector != null) {
-        LyricsSelectorDialog(
-            onDismissRequest = {
-                downloadedLyricsForSelector = null
-            },
-            onModeSelected = {
-                when (it) {
-                    LyricsMode.Plain -> {
-                        textFieldState.setContent(downloadedLyricsForSelector?.plain?.lyrics)
-                    }
-                    LyricsMode.Synced -> {
-                        textFieldState.setContent(downloadedLyricsForSelector?.synced?.lyrics)
-                    }
-                }
-                downloadedLyricsForSelector = null
-            }
-        )
-    }
-
-    if (showManualSearchDialog) {
-        AlertDialog(
-            onDismissRequest = { showManualSearchDialog = false },
-            text = { Text(stringResource(R.string.cannot_download_lyrics)) },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        context.openUrl(viewModel.getSearchUrl(song))
-                        showManualSearchDialog = false
-                    }
-                ) {
-                    Text(stringResource(R.string.yes))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showManualSearchDialog = false }) {
-                    Text(stringResource(R.string.close_action))
-                }
-            }
-        )
-    }
-
     if (showNoConnectionDialog) {
         AlertDialog(
             onDismissRequest = { showNoConnectionDialog = false },
@@ -333,6 +275,7 @@ fun LyricsEditorScreen(
             onSearchClick = { title, artist, providers ->
                 viewModel.downloadLyrics(song, title, artist, providers)
                 showLyricsDownloadDialog = false
+                onBackClick()
             },
             onDismissRequest = { showLyricsDownloadDialog = false }
         )
@@ -558,56 +501,6 @@ fun LyricsEditorScreen(
             }
         }
     }
-}
-
-@Composable
-fun LyricsSelectorDialog(
-    onDismissRequest: () -> Unit,
-    onModeSelected: (LyricsMode) -> Unit
-) {
-    var selectedMode by remember { mutableStateOf(LyricsMode.Plain) }
-
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = { Text(stringResource(R.string.choose_lyrics)) },
-        text = {
-            Column(Modifier.fillMaxWidth()) {
-                DialogListItemWithRadio(
-                    title = stringResource(R.string.plain_lyrics),
-                    onClick = {
-                        selectedMode = LyricsMode.Plain
-                    },
-                    isSelected = selectedMode == LyricsMode.Plain,
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxWidth()
-                )
-
-                DialogListItemWithRadio(
-                    title = stringResource(R.string.synced_lyrics),
-                    onClick = {
-                        selectedMode = LyricsMode.Synced
-                    },
-                    isSelected = selectedMode == LyricsMode.Synced,
-                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp),
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    onModeSelected(selectedMode)
-                }
-            ) {
-                Text(stringResource(android.R.string.ok))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(stringResource(android.R.string.cancel))
-            }
-        }
-    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsScreen.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsScreen.kt
@@ -67,6 +67,7 @@ import com.mardous.booming.core.model.player.PlayerColorScheme
 import com.mardous.booming.data.model.Song
 import com.mardous.booming.data.model.lyrics.SyncedLyrics
 import com.mardous.booming.extensions.isPowerSaveMode
+import com.mardous.booming.extensions.openUrl
 import com.mardous.booming.extensions.resolveColor
 import com.mardous.booming.ui.component.compose.AnimatedEqBars
 import com.mardous.booming.ui.component.compose.color.extractGradientColors
@@ -136,6 +137,7 @@ fun LyricsScreen(
 
     val lyricsViewSettings by lyricsViewModel.fullLyricsViewSettings.collectAsState()
     val uiState by lyricsViewModel.lyricsUiState.collectAsState()
+    val lyricsSearchState by lyricsViewModel.lyricsSearchUiState.collectAsState()
 
     val song by playerViewModel.currentSongFlow.collectAsStateWithLifecycle()
     val isPlaying by playerViewModel.isPlayingFlow.collectAsStateWithLifecycle()
@@ -170,15 +172,19 @@ fun LyricsScreen(
             .navigationBars
             .add(WindowInsets(bottom = miniPlayerMargin.totalMargin)),
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = { onEditClick(song) },
-                containerColor = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_edit_note_24dp),
-                    contentDescription = stringResource(R.string.action_lyrics_editor)
-                )
+            if (lyricsSearchState.songId != song.id ||
+                lyricsSearchState.sheetStage == LyricsSearchSheetStage.Hidden ||
+                lyricsSearchState.sheetStage == LyricsSearchSheetStage.SourceChip) {
+                FloatingActionButton(
+                    onClick = { onEditClick(song) },
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_edit_note_24dp),
+                        contentDescription = stringResource(R.string.action_lyrics_editor)
+                    )
+                }
             }
         },
         modifier = Modifier.keepScreenOn()
@@ -256,6 +262,25 @@ fun LyricsScreen(
                     .fillMaxSize()
                     .padding(innerPadding)
             )
+
+            LyricsSearchOverlay(
+                song = song,
+                state = lyricsSearchState,
+                onShowProviders = { lyricsViewModel.showLyricsSearchDetails() },
+                onShowResults = { lyricsViewModel.showLyricsSearchDetails(expanded = true) },
+                onCollapse = lyricsViewModel::collapseLyricsSearch,
+                onUseResult = { provider ->
+                    lyricsViewModel.useLyricsResult(song, provider)
+                },
+                onManualSearch = {
+                    context.openUrl(lyricsViewModel.getSearchUrl(song))
+                    lyricsViewModel.dismissLyricsSearch()
+                },
+                onDismiss = lyricsViewModel::dismissLyricsSearch,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(innerPadding)
+            )
         }
     }
 }
@@ -274,6 +299,7 @@ fun CoverLyricsScreen(
 
     val lyricsViewSettings by lyricsViewModel.playerLyricsViewSettings.collectAsState()
     val uiState by lyricsViewModel.lyricsUiState.collectAsState()
+    val lyricsSearchState by lyricsViewModel.lyricsSearchUiState.collectAsState()
 
     val playerColorScheme by playerViewModel.colorSchemeFlow.collectAsState(
         initial = PlayerColorScheme.themeColorScheme(context)
@@ -300,22 +326,44 @@ fun CoverLyricsScreen(
                 modifier = Modifier.fillMaxSize(),
             )
 
-            FilledIconButton(
-                modifier = Modifier
-                    .wrapContentSize()
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp),
-                colors = IconButtonDefaults.filledIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.onSurface,
-                    contentColor = MaterialTheme.colorScheme.surface
-                ),
-                onClick = onExpandClick
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_open_in_full_24dp),
-                    contentDescription = stringResource(R.string.action_lyrics_editor)
-                )
+            if (lyricsSearchState.songId != uiState.id ||
+                lyricsSearchState.sheetStage == LyricsSearchSheetStage.Hidden ||
+                lyricsSearchState.sheetStage == LyricsSearchSheetStage.SourceChip) {
+                FilledIconButton(
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp),
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.onSurface,
+                        contentColor = MaterialTheme.colorScheme.surface
+                    ),
+                    onClick = onExpandClick
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_open_in_full_24dp),
+                        contentDescription = stringResource(R.string.action_expand_lyrics)
+                    )
+                }
             }
+
+            val song by playerViewModel.currentSongFlow.collectAsStateWithLifecycle()
+            LyricsSearchOverlay(
+                song = song,
+                state = lyricsSearchState,
+                onShowProviders = { lyricsViewModel.showLyricsSearchDetails() },
+                onShowResults = { lyricsViewModel.showLyricsSearchDetails(expanded = true) },
+                onCollapse = lyricsViewModel::collapseLyricsSearch,
+                onUseResult = { provider ->
+                    lyricsViewModel.useLyricsResult(song, provider)
+                },
+                onManualSearch = {
+                    context.openUrl(lyricsViewModel.getSearchUrl(song))
+                    lyricsViewModel.dismissLyricsSearch()
+                },
+                onDismiss = lyricsViewModel::dismissLyricsSearch,
+                modifier = Modifier.align(Alignment.BottomStart)
+            )
         }
     }
 }

--- a/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsSearchSheet.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsSearchSheet.kt
@@ -1,0 +1,728 @@
+/*
+ * Copyright (c) 2026 Christians Martínez Alvarado
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.mardous.booming.ui.screen.lyrics
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.mardous.booming.R
+import com.mardous.booming.data.model.Song
+import com.mardous.booming.data.model.lyrics.RawLyrics
+import com.mardous.booming.data.remote.lyrics.LyricsProviderSearchResult
+import com.mardous.booming.data.remote.lyrics.LyricsProviderSearchStatus
+import com.mardous.booming.data.remote.lyrics.api.LyricsProvider
+
+@Composable
+fun LyricsSearchOverlay(
+    song: Song,
+    state: LyricsSearchUiState,
+    onShowProviders: () -> Unit,
+    onShowResults: () -> Unit,
+    onCollapse: () -> Unit,
+    onUseResult: (LyricsProvider) -> Unit,
+    onManualSearch: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (state.songId != song.id) return
+
+    var renderedStage by remember(state.songId) {
+        mutableStateOf(state.sheetStage)
+    }
+    LaunchedEffect(state.sheetStage) {
+        if (state.sheetStage != LyricsSearchSheetStage.Hidden) {
+            renderedStage = state.sheetStage
+        }
+    }
+
+    AnimatedVisibility(
+        visible = state.sheetStage != LyricsSearchSheetStage.Hidden,
+        enter = slideInVertically(tween(350)) { it / 2 } + fadeIn(tween(250)),
+        exit = slideOutVertically(tween(300)) { it / 2 } + fadeOut(tween(200)),
+        modifier = modifier
+    ) {
+        when (renderedStage) {
+            LyricsSearchSheetStage.Hidden -> Unit
+            LyricsSearchSheetStage.SourceChip -> SourceChip(
+                result = state.activeResult,
+                onClick = onShowResults
+            )
+            LyricsSearchSheetStage.Docked -> DockedLyricsSearchStrip(
+                state = state,
+                onDetailsClick = onShowProviders,
+                onExpand = onShowProviders
+            )
+            LyricsSearchSheetStage.Providers -> ProviderListSheet(
+                state = state,
+                onExpand = onShowResults,
+                onCollapse = onCollapse,
+                onManualSearch = onManualSearch,
+                onDismiss = onDismiss
+            )
+            LyricsSearchSheetStage.Results -> ResultsSheet(
+                state = state,
+                onShowProviders = onShowProviders,
+                onCollapse = onCollapse,
+                onUseResult = onUseResult
+            )
+        }
+    }
+}
+
+@Composable
+private fun SourceChip(
+    result: LyricsProviderSearchResult?,
+    onClick: () -> Unit
+) {
+    if (result == null) return
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        tonalElevation = 2.dp,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_lyrics_24dp),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = "${result.provider.displayName} · ${lyricsTypeLabel(result.lyrics)}",
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}
+
+@Composable
+private fun DockedLyricsSearchStrip(
+    state: LyricsSearchUiState,
+    onDetailsClick: () -> Unit,
+    onExpand: () -> Unit
+) {
+    SheetSurface(
+        stage = LyricsSearchSheetStage.Docked,
+        state = state,
+        onExpand = onExpand,
+        onCollapse = {}
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 8.dp, bottom = 14.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(18.dp),
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_check_24dp),
+                    contentDescription = null,
+                    modifier = Modifier.padding(10.dp).size(22.dp)
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.lyrics_search_found_better),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = stringResource(
+                        R.string.lyrics_search_progress,
+                        state.completedProviderCount,
+                        state.providerResults.size
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            TextButton(onClick = onDetailsClick) {
+                Text(stringResource(R.string.lyrics_search_details))
+            }
+        }
+        SearchProgress(state, Modifier.padding(horizontal = 16.dp))
+        Spacer(Modifier.height(14.dp))
+    }
+}
+
+@Composable
+private fun ProviderListSheet(
+    state: LyricsSearchUiState,
+    onExpand: () -> Unit,
+    onCollapse: () -> Unit,
+    onManualSearch: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    SheetSurface(
+        stage = LyricsSearchSheetStage.Providers,
+        state = state,
+        onExpand = onExpand,
+        onCollapse = onCollapse
+    ) {
+        SheetHeader(
+            title = if (state.isRunning) {
+                stringResource(R.string.lyrics_search_finding)
+            } else if (state.hasUsableResult) {
+                stringResource(R.string.lyrics_search_results)
+            } else {
+                stringResource(R.string.lyrics_search_no_results_title)
+            },
+            subtitle = if (state.isRunning) {
+                stringResource(
+                    R.string.lyrics_search_progress,
+                    state.completedProviderCount,
+                    state.providerResults.size
+                )
+            } else {
+                stringResource(R.string.lyrics_search_complete)
+            },
+            action = when {
+                state.hasUsableResult -> stringResource(R.string.lyrics_search_collapse)
+                !state.isRunning -> stringResource(R.string.close_action)
+                else -> null
+            },
+            onAction = if (!state.isRunning && !state.hasUsableResult) onDismiss else onCollapse
+        )
+
+        SearchProgress(state, Modifier.padding(horizontal = 20.dp))
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 380.dp)
+        ) {
+            items(state.providerResults, key = { it.provider.name }) { result ->
+                ProviderStatusRow(
+                    result = result,
+                    deEmphasizeErrors = state.hasUsableResult
+                )
+                if (result != state.providerResults.lastOrNull()) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 20.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                }
+            }
+        }
+
+        if (!state.isRunning && !state.hasUsableResult) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.lyrics_search_no_results_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TextButton(onClick = onManualSearch) {
+                    Text(stringResource(R.string.lyrics_search_manual_search))
+                }
+            }
+        } else {
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun ResultsSheet(
+    state: LyricsSearchUiState,
+    onShowProviders: () -> Unit,
+    onCollapse: () -> Unit,
+    onUseResult: (LyricsProvider) -> Unit
+) {
+    val recommended = state.recommendedResult ?: return
+    val otherResults = state.usableResults.filterNot { it.provider == recommended.provider }
+    val unavailableResults = state.providerResults.filterNot { it.isUsable }
+    var showUnavailable by rememberSaveable { mutableStateOf(false) }
+
+    SheetSurface(
+        stage = LyricsSearchSheetStage.Results,
+        state = state,
+        onExpand = {},
+        onCollapse = onShowProviders,
+        modifier = Modifier.fillMaxHeight(0.9f)
+    ) {
+        SheetHeader(
+            title = stringResource(R.string.lyrics_search_results),
+            subtitle = if (state.isRunning) {
+                stringResource(
+                    R.string.lyrics_search_progress,
+                    state.completedProviderCount,
+                    state.providerResults.size
+                )
+            } else {
+                stringResource(R.string.lyrics_search_complete)
+            },
+            action = stringResource(R.string.lyrics_search_collapse),
+            onAction = onCollapse
+        )
+
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(horizontal = 20.dp)
+        ) {
+            item {
+                SectionTitle(stringResource(R.string.lyrics_search_recommended))
+                RecommendedResult(
+                    result = recommended,
+                    onUse = { onUseResult(recommended.provider) }
+                )
+            }
+
+            if (otherResults.isNotEmpty()) {
+                item { SectionTitle(stringResource(R.string.lyrics_search_other_results)) }
+                items(otherResults, key = { it.provider.name }) { result ->
+                    ResultRow(result = result, onUse = { onUseResult(result.provider) })
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                }
+            }
+
+            if (unavailableResults.isNotEmpty()) {
+                item {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(16.dp))
+                            .clickable { showUnavailable = !showUnavailable }
+                            .padding(vertical = 12.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(
+                                if (showUnavailable) R.drawable.ic_keyboard_arrow_up_24dp
+                                else R.drawable.ic_keyboard_arrow_down_24dp
+                            ),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(
+                                R.string.lyrics_search_nothing_found,
+                                unavailableResults.size
+                            ),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                if (showUnavailable) {
+                    items(unavailableResults, key = { it.provider.name }) { result ->
+                        ProviderStatusRow(result = result, deEmphasizeErrors = true)
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+    }
+}
+
+@Composable
+private fun RecommendedResult(
+    result: LyricsProviderSearchResult,
+    onUse: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.45f),
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(Modifier.padding(18.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = result.provider.displayName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = lyricsTypeLabel(result.lyrics),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.lyrics_search_best_available),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+            Spacer(Modifier.height(14.dp))
+            Text(
+                text = lyricsPreview(result.lyrics),
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = recommendationReason(result.lyrics),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(14.dp))
+            Button(onClick = onUse, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.lyrics_search_use_lyrics))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResultRow(
+    result: LyricsProviderSearchResult,
+    onUse: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_lyrics_outline_24dp),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(result.provider.displayName, style = MaterialTheme.typography.titleSmall)
+            Text(
+                lyricsTypeLabel(result.lyrics),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        TextButton(onClick = onUse) {
+            Text(stringResource(R.string.lyrics_search_use))
+        }
+    }
+}
+
+@Composable
+private fun ProviderStatusRow(
+    result: LyricsProviderSearchResult,
+    deEmphasizeErrors: Boolean
+) {
+    val statusColor = when (result.status) {
+        LyricsProviderSearchStatus.Found,
+        LyricsProviderSearchStatus.Searching -> MaterialTheme.colorScheme.primary
+        LyricsProviderSearchStatus.Failed,
+        LyricsProviderSearchStatus.TimedOut -> if (deEmphasizeErrors) {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        } else {
+            MaterialTheme.colorScheme.error
+        }
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 13.dp)
+    ) {
+        ProviderStatusIcon(result.status, statusColor)
+        Spacer(Modifier.width(14.dp))
+        Column(Modifier.weight(1f)) {
+            Text(result.provider.displayName, style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = providerStatusLabel(result),
+                style = MaterialTheme.typography.bodySmall,
+                color = statusColor
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProviderStatusIcon(status: LyricsProviderSearchStatus, tint: Color) {
+    if (status == LyricsProviderSearchStatus.Searching) {
+        CircularProgressIndicator(
+            color = tint,
+            strokeWidth = 2.dp,
+            modifier = Modifier.size(24.dp)
+        )
+        return
+    }
+    val icon = when (status) {
+        LyricsProviderSearchStatus.Found -> R.drawable.ic_check_24dp
+        LyricsProviderSearchStatus.NoMatch -> R.drawable.ic_close_24dp
+        LyricsProviderSearchStatus.Failed,
+        LyricsProviderSearchStatus.TimedOut -> R.drawable.ic_error_24dp
+        LyricsProviderSearchStatus.Waiting -> R.drawable.ic_history_24dp
+        LyricsProviderSearchStatus.Searching -> return
+    }
+    Icon(
+        painter = painterResource(icon),
+        contentDescription = null,
+        tint = tint,
+        modifier = Modifier.size(24.dp)
+    )
+}
+
+@Composable
+private fun SheetHeader(
+    title: String,
+    subtitle: String,
+    action: String?,
+    onAction: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 8.dp, bottom = 12.dp)
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.headlineSmall)
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        if (action != null) {
+            TextButton(onClick = onAction) { Text(action) }
+        }
+    }
+}
+
+@Composable
+private fun SearchProgress(state: LyricsSearchUiState, modifier: Modifier = Modifier) {
+    val total = state.providerResults.size.coerceAtLeast(1)
+    val progress = state.completedProviderCount.toFloat() / total
+    val description = stringResource(
+        R.string.lyrics_search_progress,
+        state.completedProviderCount,
+        state.providerResults.size
+    )
+    LinearProgressIndicator(
+        progress = { progress },
+        color = MaterialTheme.colorScheme.primary,
+        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(5.dp)
+            .clip(RoundedCornerShape(50))
+            .semantics {
+                stateDescription = description
+                progressBarRangeInfo = ProgressBarRangeInfo(
+                    current = progress,
+                    range = 0f..1f,
+                    steps = (total - 1).coerceAtLeast(0)
+                )
+            }
+    )
+}
+
+@Composable
+private fun SheetSurface(
+    stage: LyricsSearchSheetStage,
+    state: LyricsSearchUiState,
+    onExpand: () -> Unit,
+    onCollapse: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val handleExpands = stage != LyricsSearchSheetStage.Results
+    val handleAction = if (handleExpands) onExpand else onCollapse
+    val handleDescription = stringResource(
+        if (handleExpands) R.string.lyrics_search_expand_results
+        else R.string.lyrics_search_collapse_results
+    )
+    Surface(
+        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        tonalElevation = 3.dp,
+        modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize(tween(350))
+            .lyricsSheetDragGestures(stage, state.hasUsableResult, onExpand, onCollapse)
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .align(Alignment.CenterHorizontally)
+                    .clickable(onClick = handleAction)
+                    .clearAndSetSemantics {
+                        contentDescription = handleDescription
+                        role = Role.Button
+                        onClick {
+                            handleAction()
+                            true
+                        }
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f),
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier.size(width = 42.dp, height = 4.dp)
+                ) {}
+            }
+            content()
+        }
+    }
+}
+
+private fun Modifier.lyricsSheetDragGestures(
+    stage: LyricsSearchSheetStage,
+    hasUsableResult: Boolean,
+    onExpand: () -> Unit,
+    onCollapse: () -> Unit
+): Modifier = pointerInput(stage, hasUsableResult) {
+    var dragDistance = 0f
+    val threshold = 40.dp.toPx()
+    detectVerticalDragGestures(
+        onDragStart = { dragDistance = 0f },
+        onDragEnd = {
+            when {
+                dragDistance < -threshold -> onExpand()
+                dragDistance > threshold &&
+                    (hasUsableResult || stage == LyricsSearchSheetStage.Results) -> onCollapse()
+            }
+            dragDistance = 0f
+        },
+        onDragCancel = { dragDistance = 0f }
+    ) { change, dragAmount ->
+        change.consume()
+        dragDistance += dragAmount
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(top = 12.dp, bottom = 4.dp)
+    )
+}
+
+@Composable
+private fun providerStatusLabel(result: LyricsProviderSearchResult): String {
+    return when (result.status) {
+        LyricsProviderSearchStatus.Searching -> stringResource(R.string.lyrics_search_status_searching)
+        LyricsProviderSearchStatus.Waiting -> stringResource(R.string.lyrics_search_status_waiting)
+        LyricsProviderSearchStatus.NoMatch -> stringResource(R.string.lyrics_search_status_no_match)
+        LyricsProviderSearchStatus.Failed -> stringResource(R.string.lyrics_search_status_failed)
+        LyricsProviderSearchStatus.TimedOut -> stringResource(R.string.lyrics_search_status_timed_out)
+        LyricsProviderSearchStatus.Found -> {
+            "${stringResource(R.string.lyrics_search_status_found)} · ${lyricsTypeLabel(result.lyrics)}"
+        }
+    }
+}
+
+@Composable
+private fun lyricsTypeLabel(lyrics: RawLyrics.Remote?): String = when {
+    lyrics?.hasBoth == true -> stringResource(R.string.lyrics_search_plain_and_synced)
+    lyrics?.hasSynced == true -> stringResource(R.string.lyrics_search_line_synced)
+    else -> stringResource(R.string.plain_lyrics)
+}
+
+@Composable
+private fun recommendationReason(lyrics: RawLyrics.Remote?): String = when {
+    lyrics?.hasBoth == true -> stringResource(R.string.lyrics_search_most_complete_reason)
+    lyrics?.hasSynced == true -> stringResource(R.string.lyrics_search_synced_reason)
+    else -> stringResource(R.string.lyrics_search_plain_reason)
+}
+
+private fun lyricsPreview(lyrics: RawLyrics.Remote?): String {
+    return lyrics?.lyrics.orEmpty()
+        .replace(Regex("<[^>]+>"), " ")
+        .replace(Regex("\\[[^]]+]"), " ")
+        .lineSequence()
+        .map { line -> line.trim() }
+        .filter { line -> line.isNotEmpty() }
+        .take(2)
+        .joinToString("\n")
+}

--- a/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsSearchUiState.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsSearchUiState.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Christians Martínez Alvarado
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.mardous.booming.ui.screen.lyrics
+
+import androidx.compose.runtime.Immutable
+import com.mardous.booming.data.remote.lyrics.LyricsProviderSearchResult
+import com.mardous.booming.data.remote.lyrics.api.LyricsProvider
+
+enum class LyricsSearchSheetStage {
+    Hidden,
+    Docked,
+    Providers,
+    Results,
+    SourceChip
+}
+
+@Immutable
+data class LyricsSearchUiState(
+    val songId: Long = -1,
+    val isRunning: Boolean = false,
+    val providerResults: List<LyricsProviderSearchResult> = emptyList(),
+    val sheetStage: LyricsSearchSheetStage = LyricsSearchSheetStage.Hidden,
+    val isUserInteracting: Boolean = false,
+    val selectedProvider: LyricsProvider? = null
+) {
+    val completedProviderCount: Int
+        get() = providerResults.count { it.isTerminal }
+
+    val usableResults: List<LyricsProviderSearchResult>
+        get() = providerResults.filter { it.isUsable }
+
+    val recommendedResult: LyricsProviderSearchResult?
+        get() = usableResults.maxByOrNull { it.qualityScore }
+
+    val selectedResult: LyricsProviderSearchResult?
+        get() = selectedProvider?.let { provider ->
+            usableResults.firstOrNull { it.provider == provider }
+        }
+
+    val activeResult: LyricsProviderSearchResult?
+        get() = selectedResult ?: recommendedResult
+
+    val hasUsableResult: Boolean
+        get() = activeResult != null
+
+    companion object {
+        val Idle = LyricsSearchUiState()
+    }
+}

--- a/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsViewModel.kt
+++ b/app/src/main/java/com/mardous/booming/ui/screen/lyrics/LyricsViewModel.kt
@@ -24,6 +24,8 @@ import com.mardous.booming.data.model.Song
 import com.mardous.booming.data.model.lyrics.LyricsSource
 import com.mardous.booming.data.model.lyrics.RawLyrics
 import com.mardous.booming.data.remote.lyrics.LyricsProviderParams
+import com.mardous.booming.data.remote.lyrics.LyricsProviderSearchResult
+import com.mardous.booming.data.remote.lyrics.LyricsProviderSearchStatus
 import com.mardous.booming.data.remote.lyrics.api.LyricsProvider
 import com.mardous.booming.data.repository.LyricsRepository
 import com.mardous.booming.extensions.files.belongsTo
@@ -34,6 +36,7 @@ import com.mardous.booming.util.FileUtil
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -65,8 +68,8 @@ class LyricsViewModel(
     private val _saveEvent = Channel<LyricsEditorResult>(Channel.BUFFERED)
     val saveEvent = _saveEvent.receiveAsFlow()
 
-    private val _downloadEvent = Channel<RawLyrics.Remote>(Channel.BUFFERED)
-    val downloadEvent = _downloadEvent.receiveAsFlow()
+    private val _lyricsSearchUiState = MutableStateFlow(LyricsSearchUiState.Idle)
+    val lyricsSearchUiState = _lyricsSearchUiState.asStateFlow()
 
     private val _permissionRequestEvent = Channel<List<Uri>>(Channel.BUFFERED)
     val permissionRequestEvent = _permissionRequestEvent.receiveAsFlow()
@@ -78,6 +81,9 @@ class LyricsViewModel(
     val fullLyricsViewSettings = _fullLyricsViewSettings.asStateFlow()
 
     private var lyricsJob: Job? = null
+    private var lyricsSearchJob: Job? = null
+    private var searchSheetExitJob: Job? = null
+    private var sourceChipAutoHideJob: Job? = null
 
     init {
         instrumentalDetector = createInstrumentalDetector()
@@ -86,6 +92,9 @@ class LyricsViewModel(
 
     override fun onCleared() {
         lyricsJob?.cancel()
+        lyricsSearchJob?.cancel()
+        searchSheetExitJob?.cancel()
+        sourceChipAutoHideJob?.cancel()
         preferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 
@@ -141,27 +150,275 @@ class LyricsViewModel(
     }
 
     fun downloadLyrics(song: Song, title: String, artist: String, providers: List<LyricsProvider>) =
-        viewModelScope.launch(IO) {
-            val uiState = _lyricsEditorUiState.updateAndGet {
-                if (it is LyricsEditorUiState.Visible) {
-                    it.copy(isLoading = true)
-                } else it
-            }
-            if (uiState is LyricsEditorUiState.Visible) {
-                val providerParams = LyricsProviderParams(
-                    providers = providers,
-                    ignoreWifiSetting = true,
-                    ignoreProviderSetting = true
-                )
-                val onlineLyrics = repository.downloadLyrics(song, title, artist, providerParams)
-                if (onlineLyrics != null) {
-                    _downloadEvent.send(onlineLyrics)
-                } else {
-                    _downloadEvent.send(RawLyrics.Remote())
+        startLyricsSearch(song, title, artist, providers)
+
+    private fun startLyricsSearch(
+        song: Song,
+        title: String,
+        artist: String,
+        providers: List<LyricsProvider>
+    ): Job {
+        lyricsSearchJob?.cancel()
+        searchSheetExitJob?.cancel()
+        sourceChipAutoHideJob?.cancel()
+        val searchJob = viewModelScope.launch(IO) {
+            _lyricsSearchUiState.value = LyricsSearchUiState(
+                songId = song.id,
+                isRunning = true,
+                providerResults = providers.map { provider ->
+                    LyricsProviderSearchResult(
+                        provider = provider,
+                        status = LyricsProviderSearchStatus.Waiting
+                    )
                 }
-                _lyricsEditorUiState.value = uiState.copy(isLoading = false)
+            )
+
+            val visibilityJob = launch {
+                delay(SEARCH_UI_DELAY_MILLIS)
+                _lyricsSearchUiState.update { state ->
+                    if (state.songId != song.id || !state.isRunning ||
+                        state.sheetStage != LyricsSearchSheetStage.Hidden) {
+                        state
+                    } else {
+                        state.copy(
+                            sheetStage = if (state.hasUsableResult) {
+                                LyricsSearchSheetStage.Docked
+                            } else {
+                                LyricsSearchSheetStage.Providers
+                            }
+                        )
+                    }
+                }
+            }
+
+            val providerParams = LyricsProviderParams(
+                providers = providers,
+                ignoreWifiSetting = true,
+                ignoreProviderSetting = true
+            )
+            val searchResult = repository.searchLyrics(
+                song = song,
+                searchTitle = title,
+                searchArtist = artist,
+                providerParams = providerParams
+            ) { providerResult ->
+                var resultToPreview: LyricsProviderSearchResult? = null
+                _lyricsSearchUiState.update { state ->
+                    if (state.songId != song.id) return@update state
+
+                    val previousResult = state.activeResult
+                    val updatedState = state.copy(
+                        providerResults = state.providerResults.map { current ->
+                            if (current.provider == providerResult.provider) providerResult else current
+                        }
+                    )
+                    val nextResult = updatedState.activeResult
+                    if (state.selectedProvider == null &&
+                        nextResult?.provider != previousResult?.provider) {
+                        resultToPreview = nextResult
+                    }
+
+                    if (!updatedState.isUserInteracting &&
+                        updatedState.sheetStage == LyricsSearchSheetStage.Providers &&
+                        updatedState.hasUsableResult) {
+                        updatedState.copy(sheetStage = LyricsSearchSheetStage.Docked)
+                    } else {
+                        updatedState
+                    }
+                }
+                resultToPreview?.lyrics?.let { lyrics ->
+                    showRemoteLyrics(song, lyrics)
+                }
+            }
+            if (searchResult == null) {
+                _lyricsSearchUiState.update { state ->
+                    if (state.songId != song.id) state else state.copy(
+                        providerResults = state.providerResults.map { result ->
+                            if (result.isTerminal) result else result.copy(
+                                status = LyricsProviderSearchStatus.Failed
+                            )
+                        }
+                    )
+                }
+            } else {
+                _lyricsSearchUiState.update { state ->
+                    if (state.songId != song.id) state else state.copy(
+                        providerResults = searchResult.providerResults
+                    )
+                }
+            }
+
+            visibilityJob.cancel()
+            val completedState = _lyricsSearchUiState.value
+            val activeResult = completedState.activeResult
+            if (activeResult?.lyrics != null) {
+                repository.storeDownloadedLyrics(song, activeResult.lyrics)
+                showRemoteLyrics(song, activeResult.lyrics)
+            }
+
+            val shouldAnimateSheetOut = completedState.hasUsableResult &&
+                    !completedState.isUserInteracting &&
+                    completedState.sheetStage != LyricsSearchSheetStage.Hidden &&
+                    completedState.sheetStage != LyricsSearchSheetStage.SourceChip
+
+            _lyricsSearchUiState.update { state ->
+                if (state.songId != song.id) return@update state
+                state.copy(
+                    isRunning = false,
+                    sheetStage = when {
+                        !state.hasUsableResult -> LyricsSearchSheetStage.Providers
+                        state.isUserInteracting || shouldAnimateSheetOut -> state.sheetStage
+                        else ->
+                            LyricsSearchSheetStage.SourceChip
+                    }
+                )
+            }
+            if (shouldAnimateSheetOut) {
+                animateSearchSheetOut(song.id)
+            } else if (_lyricsSearchUiState.value.sheetStage == LyricsSearchSheetStage.SourceChip) {
+                scheduleSourceChipAutoHide(song.id)
             }
         }
+        lyricsSearchJob = searchJob
+        return searchJob
+    }
+
+    fun showLyricsSearchDetails(expanded: Boolean = false) {
+        sourceChipAutoHideJob?.cancel()
+        _lyricsSearchUiState.update { state ->
+            if (state == LyricsSearchUiState.Idle) state else state.copy(
+                sheetStage = if (expanded && state.hasUsableResult) {
+                    LyricsSearchSheetStage.Results
+                } else {
+                    LyricsSearchSheetStage.Providers
+                },
+                isUserInteracting = true
+            )
+        }
+    }
+
+    fun collapseLyricsSearch() {
+        val currentState = _lyricsSearchUiState.value
+        val shouldAnimateSheetOut = !currentState.isRunning &&
+                currentState.hasUsableResult &&
+                currentState.sheetStage != LyricsSearchSheetStage.Hidden &&
+                currentState.sheetStage != LyricsSearchSheetStage.SourceChip
+        _lyricsSearchUiState.update { state ->
+            state.copy(
+                sheetStage = when {
+                    state.isRunning && state.hasUsableResult -> LyricsSearchSheetStage.Docked
+                    state.isRunning -> LyricsSearchSheetStage.Providers
+                    shouldAnimateSheetOut -> state.sheetStage
+                    state.hasUsableResult -> LyricsSearchSheetStage.SourceChip
+                    else -> LyricsSearchSheetStage.Hidden
+                },
+                isUserInteracting = false
+            )
+        }
+        val state = _lyricsSearchUiState.value
+        if (shouldAnimateSheetOut) {
+            animateSearchSheetOut(state.songId)
+        } else if (state.sheetStage == LyricsSearchSheetStage.SourceChip) {
+            scheduleSourceChipAutoHide(state.songId)
+        }
+    }
+
+    fun useLyricsResult(song: Song, provider: LyricsProvider) = viewModelScope.launch(IO) {
+        val result = _lyricsSearchUiState.value.providerResults.firstOrNull {
+            it.provider == provider && it.isUsable
+        } ?: return@launch
+        val lyrics = result.lyrics ?: return@launch
+
+        repository.storeDownloadedLyrics(song, lyrics)
+        showRemoteLyrics(song, lyrics)
+        val currentState = _lyricsSearchUiState.value
+        val shouldAnimateSheetOut = !currentState.isRunning &&
+                currentState.sheetStage != LyricsSearchSheetStage.Hidden &&
+                currentState.sheetStage != LyricsSearchSheetStage.SourceChip
+        _lyricsSearchUiState.update { state ->
+            state.copy(
+                selectedProvider = provider,
+                sheetStage = when {
+                    state.isRunning -> LyricsSearchSheetStage.Docked
+                    shouldAnimateSheetOut -> state.sheetStage
+                    else -> LyricsSearchSheetStage.SourceChip
+                },
+                isUserInteracting = false
+            )
+        }
+        if (shouldAnimateSheetOut) {
+            animateSearchSheetOut(song.id)
+        } else if (_lyricsSearchUiState.value.sheetStage == LyricsSearchSheetStage.SourceChip) {
+            scheduleSourceChipAutoHide(song.id)
+        }
+    }
+
+    fun dismissLyricsSearch() {
+        sourceChipAutoHideJob?.cancel()
+        _lyricsSearchUiState.update { state ->
+            if (state.isRunning) state else LyricsSearchUiState.Idle
+        }
+    }
+
+    private fun scheduleSourceChipAutoHide(songId: Long) {
+        sourceChipAutoHideJob?.cancel()
+        sourceChipAutoHideJob = viewModelScope.launch {
+            delay(SOURCE_CHIP_VISIBLE_MILLIS)
+            _lyricsSearchUiState.update { state ->
+                if (state.songId == songId &&
+                    !state.isRunning &&
+                    !state.isUserInteracting &&
+                    state.sheetStage == LyricsSearchSheetStage.SourceChip) {
+                    state.copy(sheetStage = LyricsSearchSheetStage.Hidden)
+                } else {
+                    state
+                }
+            }
+        }
+    }
+
+    private fun animateSearchSheetOut(songId: Long) {
+        searchSheetExitJob?.cancel()
+        sourceChipAutoHideJob?.cancel()
+        searchSheetExitJob = viewModelScope.launch {
+            _lyricsSearchUiState.update { state ->
+                if (state.songId == songId && !state.isRunning && state.hasUsableResult) {
+                    state.copy(sheetStage = LyricsSearchSheetStage.Hidden)
+                } else {
+                    state
+                }
+            }
+            delay(SEARCH_SHEET_EXIT_MILLIS)
+            _lyricsSearchUiState.update { state ->
+                if (state.songId == songId && !state.isRunning &&
+                    !state.isUserInteracting && state.hasUsableResult &&
+                    state.sheetStage == LyricsSearchSheetStage.Hidden) {
+                    state.copy(sheetStage = LyricsSearchSheetStage.SourceChip)
+                } else {
+                    state
+                }
+            }
+            if (_lyricsSearchUiState.value.sheetStage == LyricsSearchSheetStage.SourceChip) {
+                scheduleSourceChipAutoHide(songId)
+            }
+        }
+    }
+
+    private suspend fun showRemoteLyrics(song: Song, lyrics: RawLyrics.Remote) {
+        if (_lyricsSearchUiState.value.songId != song.id) return
+        val storedLyrics = lyrics.prepareToStore() ?: return
+        if (storedLyrics.instrumental) {
+            _lyricsUiState.value = LyricsUiState.Instrumental(song.id)
+            return
+        }
+
+        val syncedLyrics = repository.parseRawLyrics(song, storedLyrics)
+        _lyricsUiState.value = if (syncedLyrics?.hasContent == true) {
+            LyricsUiState.Synced(song.id, syncedLyrics)
+        } else {
+            LyricsUiState.Plain(song.id, storedLyrics.lyrics.orEmpty())
+        }
+    }
 
     fun preparePermissionRequest(song: Song) = viewModelScope.launch(IO) {
         _permissionRequestEvent.send(repository.writableUris(song))
@@ -229,6 +486,12 @@ class LyricsViewModel(
     }
 
     fun updateSong(song: Song) {
+        if (_lyricsSearchUiState.value.songId != -1L &&
+            _lyricsSearchUiState.value.songId != song.id) {
+            lyricsSearchJob?.cancel()
+            sourceChipAutoHideJob?.cancel()
+            _lyricsSearchUiState.value = LyricsSearchUiState.Idle
+        }
         lyricsJob?.cancel()
         lyricsJob = viewModelScope.launch {
             if (song == Song.emptySong) {
@@ -444,6 +707,9 @@ class LyricsViewModel(
 
     companion object {
         private const val INSTRUMENTAL_IDENTIFIER_MAX_LENGTH = 50
+        private const val SEARCH_UI_DELAY_MILLIS = 600L
+        private const val SEARCH_SHEET_EXIT_MILLIS = 325L
+        private const val SOURCE_CHIP_VISIBLE_MILLIS = 4_000L
         private const val INSTRUMENTAL_TRACK_IDENTIFIERS = "instrumental_track_identifiers"
         private const val MARK_INSTRUMENTAL_BY_TITLE = "mark_instrumental_tracks_by_title"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -571,6 +571,36 @@
     <string name="could_not_import_font">Could not import font.</string>
     <string name="cannot_edit_lyrics_file">You cannot edit the file content directly from Booming Music.</string>
     <string name="lyrics_by_x">Lyrics by %s</string>
+    <string name="lyrics_search_finding">Finding lyrics</string>
+    <string name="lyrics_search_progress">%1$d of %2$d providers checked</string>
+    <string name="lyrics_search_found_better">Lyrics found — checking for a better result</string>
+    <string name="lyrics_search_details">Details</string>
+    <string name="lyrics_search_collapse">Collapse</string>
+    <string name="lyrics_search_results">Lyrics results</string>
+    <string name="lyrics_search_complete">Search complete</string>
+    <string name="lyrics_search_recommended">Recommended</string>
+    <string name="lyrics_search_other_results">Other results</string>
+    <string name="lyrics_search_nothing_found">Nothing found · %1$d providers</string>
+    <string name="lyrics_search_use">Use</string>
+    <string name="lyrics_search_use_lyrics">Use lyrics</string>
+    <string name="lyrics_search_best_available">Best available</string>
+    <string name="lyrics_search_line_synced">Line synced</string>
+    <string name="lyrics_search_plain_and_synced">Plain and line synced</string>
+    <string name="lyrics_search_status_searching">Searching</string>
+    <string name="lyrics_search_status_waiting">Waiting</string>
+    <string name="lyrics_search_status_found">Found</string>
+    <string name="lyrics_search_status_no_match">No match</string>
+    <string name="lyrics_search_status_failed">Failed</string>
+    <string name="lyrics_search_status_timed_out">Timed out</string>
+    <string name="lyrics_search_no_results_title">No lyrics found</string>
+    <string name="lyrics_search_no_results_message">None of the selected providers returned usable lyrics.</string>
+    <string name="lyrics_search_manual_search">Search manually</string>
+    <string name="lyrics_search_most_complete_reason">Includes both plain and line-synced lyrics</string>
+    <string name="lyrics_search_synced_reason">Line-synced lyrics are preferred for playback</string>
+    <string name="lyrics_search_plain_reason">Best available text result</string>
+    <string name="lyrics_search_expand_results">Expand lyrics results</string>
+    <string name="lyrics_search_collapse_results">Collapse lyrics results</string>
+    <string name="action_expand_lyrics">Expand lyrics</string>
 
     <!-- Scrobbling Service -->
     <string name="sign_in_to_x_title">Sign in to %s</string>


### PR DESCRIPTION
## Description

This PR introduces a non-modal, progressively disclosed interface for multi-provider lyrics searches.

Users can now see which providers are being checked, receive the first usable lyrics immediately, inspect alternative results, and understand why a result was recommended—without interrupting playback or covering the lyrics unnecessarily.

### What changed

- Added live provider states: Waiting, Searching, Found, No match, Failed, and Timed out.
- Added three search presentation levels: a compact docked strip, provider status list, and expanded results.
- Shows the first usable result while continuing to search for a better one.
- Recommends results based on lyrics quality: plain and line-synced, line-synced, then plain.
- Groups unavailable providers under a collapsible “Nothing found” section.
- Added a 600 ms fast path to avoid showing search UI for quick results.
- Added an animated transition from the completed search sheet to a compact source chip.
- Automatically hides the source chip after four seconds using a fade and slide-out animation.
- Keeps the player visible and interactive throughout the search.
- Improved LRCLib handling for responses with missing duration values.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no functional changes)
- [ ] Performance optimization
- [ ] Documentation update

## AI Agent Usage Disclosure

- [x] **I used an AI agent (e.g., Gemini, Claude, ChatGPT) to assist with this code.**
  - OpenAI Codex assisted with UX implementation, lyrics-search state management, animations, and emulator testing.
- [ ] I did NOT use an AI agent for this contribution.

## Testing

- Built the GitHub debug variant successfully with: .\gradlew.bat :app:testGithubDebugUnitTest :app:assembleGithubDebug
- The project currently contains no unit-test sources for this variant (NO-SOURCE).
- Manually verified on an Android emulator:
  - Search starting without existing lyrics
  - First result while other providers remain active
  - Mixed Found, No match, and Failed states
  - Recommended and unavailable result groups
  - Animated search-sheet dismissal
  - Source-chip reopening and automatic animated dismissal
  - Small-screen layout and non-modal player visibility

## Checklist

- [x] My code follows the project's coding style and guidelines.
- [x] I have verified that my changes do not compromise user experience or performance.

## Screenshots / Videos

https://github.com/user-attachments/assets/cf583cf5-9e31-4e9a-8fcc-5ca673a4171b

